### PR TITLE
Implement Wallet.pay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .settings
 .classpath
 .recommenders
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,12 @@ SOFTWARE.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.llorllale</groupId>
+      <artifactId>cactoos-matchers</artifactId>
+      <version>0.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>2.4.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,9 @@ SOFTWARE.
                   <goal>check</goal>
                 </goals>
                 <configuration>
+                  <excludes>
+                    <exclude>**/*Envelope.class</exclude>
+                  </excludes>
                   <rules>
                     <rule>
                       <element>BUNDLE</element>
@@ -192,6 +195,12 @@ SOFTWARE.
     <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.victornoel.eo</groupId>
+      <artifactId>eo-envelopes</artifactId>
+      <version>0.0.3</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>

--- a/src/main/java/io/zold/api/CpTransaction.java
+++ b/src/main/java/io/zold/api/CpTransaction.java
@@ -27,8 +27,9 @@ package io.zold.api;
  * Computed Transaction.
  *
  * @since 1.0
- * @todo #29:30min Implement transaction string computation based on
- *  the white paper. Also update the unit test to ensure it works.
+ * @todo #29:30min Implement the computation of the transaction string
+ *  based on the white paper. The unit test should also be updated to
+ *  ensure it works as expected.
  */
 public final class CpTransaction extends TransactionEnvelope {
 

--- a/src/main/java/io/zold/api/CpTransaction.java
+++ b/src/main/java/io/zold/api/CpTransaction.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.zold.api;
+
+/**
+ * Computed Transaction.
+ *
+ * @since 1.0
+ * @todo #29:30min Implement transaction string computation based on
+ *  the white paper. Also update the unit test to ensure it works.
+ */
+public final class CpTransaction extends TransactionEnvelope {
+
+    /**
+     * Ctor.
+     *
+     * @param amt Amount to pay in zents
+     * @param bnf Wallet ID of beneficiary
+     */
+    CpTransaction(final long amt, final long bnf) {
+        super(new RtTransaction(Long.toString(amt + bnf)));
+    }
+}

--- a/src/main/java/io/zold/api/Transaction.java
+++ b/src/main/java/io/zold/api/Transaction.java
@@ -23,6 +23,7 @@
  */
 package io.zold.api;
 
+import com.github.victornoel.eo.GenerateEnvelope;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 
@@ -31,6 +32,7 @@ import java.time.ZonedDateTime;
  *
  * @since 0.1
  */
+@GenerateEnvelope
 public interface Transaction {
 
     /**
@@ -77,4 +79,13 @@ public interface Transaction {
      * @return RSA Signature
      */
     String signature();
+
+    @Override
+    boolean equals(Object obj);
+
+    @Override
+    int hashCode();
+
+    @Override
+    String toString();
 }

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -23,7 +23,9 @@
  */
 package io.zold.api;
 
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.file.Path;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.iterable.Skipped;
@@ -51,8 +53,9 @@ public interface Wallet {
      * Make a payment.
      * @param amt Amount to pay in zents
      * @param bnf Wallet ID of beneficiary
+     * @throws IOException If an IO error occurs
      */
-    void pay(long amt, long bnf);
+    void pay(long amt, long bnf) throws IOException;
 
     /**
      * Merge both {@code this} and {@code other}. Fails if they are not the
@@ -104,13 +107,12 @@ public interface Wallet {
             ).value();
         }
 
-        // @todo #15:30min Implement pay method. This should add a transaction
-        //  to the wallet containing the correct details with the help of
-        //  RtTransaction class. Also add a unit test to replace
-        //  WalletTest.payIsNotYetImplemented().
         @Override
-        public void pay(final long amt, final long bnf) {
-            throw new UnsupportedOperationException("pay() not yet supported");
+        public void pay(final long amt, final long bnf) throws IOException {
+            try (final Writer out = new FileWriter(this.path.toFile(), true)) {
+                out.write('\n');
+                out.write(new CpTransaction(amt, bnf).toString());
+            }
         }
 
         // @todo #6:30min Implement merge method. This should merge this wallet

--- a/src/test/java/io/zold/api/CpTransactionTest.java
+++ b/src/test/java/io/zold/api/CpTransactionTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.zold.api;
+
+import org.junit.Test;
+
+/**
+ * Test case for {@link CpTransaction}.
+ *
+ * @since 1.0
+ * @checkstyle LineLengthCheck (500 lines)
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public final class CpTransactionTest {
+    @Test(expected = UnsupportedOperationException.class)
+    public void cpTransactionIsNotYetImplemented() {
+        new CpTransaction(1, 1234).amount();
+    }
+}

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -24,15 +24,20 @@
 package io.zold.api;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.hamcrest.core.IsEqual;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.FuncApplies;
 
 /**
  * Test case for {@link Wallet}.
@@ -68,9 +73,24 @@ public final class WalletTest {
         new Wallet.File(this.wallet("invalid_id")).id();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void payIsNotYetImplemented() throws IOException {
-        new Wallet.File(this.folder.newFile().toPath()).pay(1, 1234);
+    @Test
+    public void pay() throws IOException {
+        final Path path = this.folder.newFile().toPath();
+        path.toFile().delete();
+        Files.copy(this.wallet(5124095577148911L), path);
+        final Wallet wallet = new Wallet.File(path);
+        MatcherAssert.assertThat(
+            wlt -> {
+                wlt.pay(1, 1234);
+                return wlt.ledger();
+            },
+            new FuncApplies<>(
+                wallet,
+                new IsIterableWithSize<Transaction>(
+                    new IsEqual<>(new ListOf<>(wallet.ledger()).size() + 1)
+                )
+            )
+        );
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
This is for #29:
- implement Wallet.pay by writing the transaction at the end of the wallet
- introduced a `@todo` to implement a computed transaction (`CpTransaction`)

Note that I used [eo-envelope](https://github.com/victornoel/eo-envelopes) to generate an envelope instead of writing it. @yegor256 said in the past he would agree to use this library in its project and I have been using it for a month or two in real world projects without any problems.
I would expect @llorllale to validate this choice as ARC.