### PR TITLE
Implement Network.pull

### DIFF
--- a/src/main/java/io/zold/api/Copies.java
+++ b/src/main/java/io/zold/api/Copies.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.zold.api;
+
+import io.zold.api.Copies.Copy;
+import org.cactoos.iterable.IterableEnvelope;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.Mapped;
+
+/**
+ * Multiple copies of a Wallet.
+ *
+ * @since 1.0
+ * @todo #41:30min The constructor of Copies should be implemented
+ *  to retrieve the Wallet with the provided id in the provided remotes and
+ *  group them by equivalent wallet (i.e., equivalent content) along
+ *  with their remotes as explained in the whitepaper. A unit test should be
+ *  added to validate this behaviour. The unit test
+ *  NetworkTest.pullIsNotYetImplemented() should also be removed and replaced
+ *  with a real test.
+ */
+public final class Copies extends IterableEnvelope<Copy> {
+
+    /**
+     * Ctor.
+     *
+     * @param id Id of the wallet to pull.
+     * @param remotes Remote nodes.
+     */
+    Copies(final long id, final Iterable<Remote> remotes) {
+        super(() -> new IterableOf<>(new Copy(new Wallet.Fake(id), remotes)));
+    }
+
+    /**
+     * One copy of a {@link Wallet}.
+     *
+     * @since 1.0
+     */
+    static final class Copy implements Comparable<Copy> {
+
+        /**
+         * The wallet.
+         */
+        private final Wallet wlt;
+
+        /**
+         * The remote nodes where the wallet was found.
+         */
+        private final Iterable<Remote> remotes;
+
+        /**
+         * Ctor.
+         *
+         * @param wallet The wallet.
+         * @param remotes The remote nodes where the wallet was found.
+         */
+        Copy(final Wallet wallet, final Iterable<Remote> remotes) {
+            this.wlt = wallet;
+            this.remotes = remotes;
+        }
+
+        /**
+         * The wallet.
+         *
+         * @return The wallet.
+         */
+        public Wallet wallet() {
+            return this.wlt;
+        }
+
+        /**
+         * The summary of the score of all the remote nodes.
+         *
+         * @return The score.
+         */
+        public Score score() {
+            return new Score.Summed(new Mapped<>(Remote::score, this.remotes));
+        }
+
+        @Override
+        public int compareTo(final Copy other) {
+            return this.score().compareTo(other.score());
+        }
+    }
+}

--- a/src/main/java/io/zold/api/Network.java
+++ b/src/main/java/io/zold/api/Network.java
@@ -23,6 +23,8 @@
  */
 package io.zold.api;
 
+import java.io.IOException;
+
 /**
  * Network of remote nodes.
  *
@@ -40,7 +42,8 @@ public interface Network extends Iterable<Remote> {
      * Pull a wallet from the network.
      * @param id The wallet's {@link Wallet#id() id}
      * @return The wallet
+     * @throws IOException If an IO error occurs
      */
-    Wallet pull(long id);
+    Wallet pull(long id) throws IOException;
 
 }

--- a/src/main/java/io/zold/api/Network.java
+++ b/src/main/java/io/zold/api/Network.java
@@ -41,6 +41,6 @@ public interface Network extends Iterable<Remote> {
      * @param id The wallet's {@link Wallet#id() id}
      * @return The wallet
      */
-    Wallet pull(Long id);
+    Wallet pull(long id);
 
 }

--- a/src/main/java/io/zold/api/RtNetwork.java
+++ b/src/main/java/io/zold/api/RtNetwork.java
@@ -23,7 +23,12 @@
  */
 package io.zold.api;
 
+import java.io.IOException;
 import java.util.Iterator;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.iterable.Sorted;
+import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.Reduced;
 
 /**
  * Network implementation.
@@ -60,14 +65,17 @@ public final class RtNetwork implements Network {
         );
     }
 
-    // @todo #5:30min Implement pull method. Pulling a wallet from the
-    //  network should return all the wallets with that id in the
-    //  network merged together. After the implementation
-    //  NetworkTest.pullIsNotYetImplemented() have to be uncommented and
-    //  test if pull method is behaving correctly.
     @Override
-    public Wallet pull(final long id) {
-        throw new UnsupportedOperationException("pull(id) not supported");
+    public Wallet pull(final long id) throws IOException {
+        return new IoCheckedScalar<>(
+            new Reduced<>(
+                Wallet::merge,
+                new Mapped<>(
+                    c -> c::wallet,
+                    new Sorted<>(new Copies(id, this))
+                )
+            )
+        ).value();
     }
 
     @Override

--- a/src/main/java/io/zold/api/RtNetwork.java
+++ b/src/main/java/io/zold/api/RtNetwork.java
@@ -66,7 +66,7 @@ public final class RtNetwork implements Network {
     //  NetworkTest.pullIsNotYetImplemented() have to be uncommented and
     //  test if pull method is behaving correctly.
     @Override
-    public Wallet pull(final Long id) {
+    public Wallet pull(final long id) {
         throw new UnsupportedOperationException("pull(id) not supported");
     }
 

--- a/src/main/java/io/zold/api/RtScore.java
+++ b/src/main/java/io/zold/api/RtScore.java
@@ -21,31 +21,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.zold.api;
 
+import org.cactoos.Text;
+import org.cactoos.iterable.LengthOf;
+
 /**
- * Remote node.
+ * Default implementation for {@link Score}.
  *
- * @since 0.1
+ * @since 1.0
  */
-public interface Remote {
-    /**
-     * This remote node's score.
-     * @return The score
-     */
-    Score score();
+public final class RtScore implements Score {
 
     /**
-     * Pushes a {@link Wallet} to this remote.
-     * @param wallet Wallet to be pushed to this remote
+     * The suffixes.
      */
-    void push(Wallet wallet);
+    private final Iterable<Text> sfxs;
 
     /**
-     * Pull a wallet from this remote.
-     * @param id The wallet's {@link Wallet#id() id}
-     * @return The wallet
+     * Ctor.
+     *
+     * @param sfxs The suffixes.
      */
-    Wallet pull(long id);
+    RtScore(final Iterable<Text> sfxs) {
+        this.sfxs = sfxs;
+    }
+
+    @Override
+    public int compareTo(final Score other) {
+        return new LengthOf(other.suffixes()).intValue()
+            - new LengthOf(this.sfxs).intValue();
+    }
+
+    @Override
+    public Iterable<Text> suffixes() {
+        return this.sfxs;
+    }
 }

--- a/src/main/java/io/zold/api/Score.java
+++ b/src/main/java/io/zold/api/Score.java
@@ -21,21 +21,47 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.zold.api;
 
+import com.github.victornoel.eo.GenerateEnvelope;
 import org.cactoos.Text;
+import org.cactoos.iterable.Joined;
+import org.cactoos.iterable.Mapped;
 
 /**
  * A remote node's score, equal to its number of suffixes.
  *
+ * The natural order of {@link Score} is from highest to lowest.
+ *
+ * Note: {@link Score} has a natural ordering that is inconsistent with equals.
+ *
  * @since 0.1
  */
+@GenerateEnvelope
 public interface Score extends Comparable<Score> {
+
     /**
      * The suffixes associated with this score. Each suffix is a text of the
      * form {@code /[a-zA-Z0-9]+/}.
      * @return Suffixes for this score
      */
     Iterable<Text> suffixes();
+
+    /**
+     * Summary of multiple {@link Score}.
+     *
+     * @since 1.0
+     */
+    final class Summed extends ScoreEnvelope {
+        /**
+         * Ctor.
+         *
+         * @param scores Multiple scores to summary.
+         */
+        Summed(final Iterable<Score> scores) {
+            super(new RtScore(
+                new Joined<>(new Mapped<>(Score::suffixes, scores))
+            ));
+        }
+    }
 }

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -27,6 +27,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.iterable.Skipped;
 import org.cactoos.list.ListOf;
@@ -39,7 +40,7 @@ import org.cactoos.text.TextOf;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.ShortMethodName")
+@SuppressWarnings({"PMD.ShortMethodName", "PMD.TooManyMethods"})
 public interface Wallet {
     /**
      * This wallet's ID: an unsigned 64-bit integer.
@@ -72,10 +73,52 @@ public interface Wallet {
     Iterable<Transaction> ledger();
 
     /**
+     * A Fake {@link Wallet}.
+     *
+     * @since 1.0
+     */
+    final class Fake implements Wallet {
+
+        /**
+         * The wallet id.
+         */
+        private final long id;
+
+        /**
+         * Ctor.
+         *
+         * @param id The wallet id.
+         */
+        public Fake(final long id) {
+            this.id = id;
+        }
+
+        @Override
+        public long id() throws IOException {
+            return this.id;
+        }
+
+        @Override
+        public void pay(final long amt, final long bnf) {
+            // nothing
+        }
+
+        @Override
+        public Wallet merge(final Wallet other) {
+            return other;
+        }
+
+        @Override
+        public Iterable<Transaction> ledger() {
+            return new IterableOf<>();
+        }
+    }
+
+    /**
      * Default File implementation.
      * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
      */
-    class File implements Wallet {
+    final class File implements Wallet {
 
         /**
          * Path of this wallet.

--- a/src/test/java/io/zold/api/NetworkTest.java
+++ b/src/test/java/io/zold/api/NetworkTest.java
@@ -23,10 +23,12 @@
  */
 package io.zold.api;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Repeated;
 import org.cactoos.text.RandomText;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -114,9 +116,13 @@ public final class NetworkTest {
         ).push(Mockito.any(Wallet.class));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void pullNotYetSupported() {
-        new RtNetwork(new ArrayList<>(1)).pull(1L);
+    @Test
+    public void pullsWalletWithTheRightId() throws IOException {
+        final long id = 1L;
+        MatcherAssert.assertThat(
+            new RtNetwork(new IterableOf<>()).pull(id).id(),
+            new IsEqual<>(id)
+        );
     }
 
 }

--- a/src/test/java/io/zold/api/ScoreTest.java
+++ b/src/test/java/io/zold/api/ScoreTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.zold.api;
+
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.list.ListOf;
+import org.cactoos.list.Sorted;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+
+/**
+ * Test case for {@link Score}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class ScoreTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void fewerSuffixesComeAfter() {
+        final Score lowest = new RtScore(
+            new IterableOf<>(new TextOf("a"))
+        );
+        final Score highest = new RtScore(
+            new IterableOf<>(new TextOf("b"), new TextOf("c"))
+        );
+        MatcherAssert.assertThat(
+            new Sorted<>(lowest, highest),
+            new IsIterableContainingInOrder<>(
+                new ListOf<>(new IsEqual<>(highest), new IsEqual<>(lowest))
+            )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void sumWithFewerSuffixesComesAfter() {
+        final Score lowest = new RtScore(
+            new IterableOf<>(new TextOf("a"))
+        );
+        final Score highone = new RtScore(
+            new IterableOf<>(new TextOf("b"), new TextOf("c"))
+        );
+        final Score hightwo = new RtScore(
+            new IterableOf<>(new TextOf("d"), new TextOf("e"))
+        );
+        final Score sum = new Score.Summed(new IterableOf<>(lowest, highone));
+        MatcherAssert.assertThat(
+            new Sorted<>(sum, hightwo),
+            new IsIterableContainingInOrder<>(
+                new ListOf<>(
+                    new IsEqual<>(sum),
+                    new IsEqual<>(hightwo)
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
This is for #41:
- Implement basic pull algorithm: fetch + merge.
- Does not implement grouping the remote copies with their remotes (added a `@todo` for that)
- Implement some basic scoring facilities for sorting remotes and copies based on their score.

I spent a bit too much time on this, so I didn't make extra effort with tests, but I believe that when what is missing is implemented, it will be meaningful to add tests at that time.