### PR TITLE
#34: Wallet Exception handling

### DIFF
--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -30,6 +30,8 @@ import java.nio.file.Paths;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -61,10 +61,15 @@ public final class WalletTest {
         MatcherAssert.assertThat(wallet.id(), Matchers.is(id));
     }
 
-    @Ignore
     @Test
-    public void throwIoExceptionIfReadingIdFails() throws IOException {
-        this.error.expect(IOException.class);
+    public void throwRuntimeExceptionIfReadingIdFails() throws IOException {
+        this.error.expect(RuntimeException.class);
+        new Wallet.File(this.wallet("")).id();
+    }
+
+    @Test
+    public void throwRuntimeExceptionIfIdIsInvalid() throws IOException {
+        this.error.expect(RuntimeException.class);
         new Wallet.File(this.wallet("invalid_id")).id();
     }
 

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -38,10 +38,6 @@ import org.junit.rules.TemporaryFolder;
  * Test case for {@link Wallet}.
  *
  * @since 0.1
- * @todo #33:30min CheckedScalar from 'cactoos' does not wrap runtime
- *  exceptions for some reason. Once it's fixed (see yegor256/cactoos#933)
- *  un-ignore WalletTest.throwIoExceptionIfReadingIdFails and make sure
- *  it works.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -63,8 +63,9 @@ public final class WalletTest {
     }
 
     @Test
-    public void throwRuntimeExceptionIfIdIsInvalid() throws IOException {
-        this.error.expect(RuntimeException.class);
+    public void throwNumberFormatExceptionIfIdIsInvalid() throws IOException {
+        this.error.expect(NumberFormatException.class);
+        this.error.expectMessage("For input string:");
         new Wallet.File(this.wallet("invalid_id")).id();
     }
 


### PR DESCRIPTION
#34 asked:

> CheckedScalar from 'cactoos' does not wrap runtime  exceptions for some reason. Once it's fixed (see yegor256/cactoos#933)  un-ignore WalletTest.throwIoExceptionIfReadingIdFails and make sure  it works. 

But it was decided in yegor256/cactoos#933 that `CheckedScalar` library WON'T wrap `RuntimeExceptions` and will be left as is for now.

I've changed `throwIoExceptionIfReadingIdFails`  to `throwRuntimeExceptionIfReadingIdFails` reflecting this decision and added `throwRuntimeExceptionIfIdIsInvalid` to test if we are trying to read an invalid wallet.