### PR TITLE
Implement partially WalletsIn.create

### DIFF
--- a/src/main/java/io/zold/api/Wallets.java
+++ b/src/main/java/io/zold/api/Wallets.java
@@ -24,6 +24,8 @@
 
 package io.zold.api;
 
+import java.io.IOException;
+
 /**
  * Wallets.
  *
@@ -32,7 +34,9 @@ package io.zold.api;
 public interface Wallets extends Iterable<Wallet> {
     /**
      * Create a wallet.
-     * @return The new wallet
+     * @param id The new wallet id.
+     * @return The new wallet.
+     * @throws IOException If an error occurs.
      */
-    Wallet create();
+    Wallet create(final long id) throws IOException;
 }

--- a/src/main/java/io/zold/api/WalletsIn.java
+++ b/src/main/java/io/zold/api/WalletsIn.java
@@ -25,6 +25,7 @@ package io.zold.api;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import org.cactoos.Scalar;
@@ -35,11 +36,17 @@ import org.cactoos.iterable.Mapped;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.cactoos.scalar.StickyScalar;
 import org.cactoos.scalar.SyncScalar;
+import org.cactoos.text.JoinedText;
 
 /**
  * Wallets in path.
  *
  * @since 0.1
+ * @todo #12:30min Make uniform the way file extensions are handled
+ *  in this class. Currently there is on one hand a filter that
+ *  matches files ending with "z" and in the other hand a the
+ *  create method that write files with extension "z". Instead
+ *  the same extension should be used in both.
  * @checkstyle ClassDataAbstractionCoupling (2 lines)
  */
 public final class WalletsIn implements Wallets {
@@ -84,17 +91,19 @@ public final class WalletsIn implements Wallets {
         );
     }
 
-    // @todo #4:30min Return the new instance of the Wallet, that will
-    //  be created in the path with all wallets. Should be taken care of
-    //  after Wallet interface will have implementations. Cover with tests and
-    //  remove irrelevant test case.
+    // @todo #12:30min Create the new wallet in the path with all wallets.
+    //  It should contain the correct content according to the
+    //  white paper. Then enable the test createsWalletWithId.
     @Override
-    public Wallet create() {
-        throw new UnsupportedOperationException("create() not yet supported");
+    public Wallet create(final long id) throws IOException {
+        final Path wpth = this.path.value().resolve(
+            new JoinedText(".", Long.toHexString(id), "z").asString()
+        );
+        Files.createFile(wpth);
+        return new Wallet.File(wpth);
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public Iterator<Wallet> iterator() {
         try {
             return new Mapped<Path, Wallet>(

--- a/src/test/java/io/zold/api/WalletsInTest.java
+++ b/src/test/java/io/zold/api/WalletsInTest.java
@@ -24,9 +24,14 @@
 package io.zold.api;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,6 +41,11 @@ import org.junit.rules.TemporaryFolder;
  * Test case for {@link WalletsIn}.
  *
  * @since 0.1
+ * @todo #12:30min The name of the wallets in the test
+ *  resource directory are not compliant with how
+ *  wallets should be named (see white paper and WalletsIn).
+ *  They should be made adequate and a test should be added to
+ *  ensure WalletsIn.create does overwrite and existing wallet.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
  */
@@ -52,20 +62,45 @@ public final class WalletsInTest {
         MatcherAssert.assertThat(
             new WalletsIn(Paths.get("src/test/resources/walletsIn")),
             // @checkstyle MagicNumber (1 line)
-            Matchers.iterableWithSize(5)
+            new IsIterableWithSize<>(new IsEqual<>(5))
+        );
+    }
+
+    @Ignore("see @todo on WalletsIn.create")
+    @Test
+    public void createsWalletWithId() throws IOException {
+        final long id = 1L;
+        MatcherAssert.assertThat(
+            "Can't create wallet with id",
+            new WalletsIn(this.folder.newFolder().toPath()).create(id).id(),
+            new IsEqual<>(id)
         );
     }
 
     @Test
-    public void createIsNotYetImplemented() throws IOException {
-        this.thrown.expect(UnsupportedOperationException.class);
-        this.thrown.expectMessage(
-            Matchers.is(
-                "create() not yet supported"
-            )
+    public void createsWalletInWallets() throws IOException {
+        final Wallets wallets = new WalletsIn(this.folder.newFolder().toPath());
+        wallets.create(1L);
+        MatcherAssert.assertThat(
+            "Can't create wallet in wallets",
+            wallets,
+            new IsIterableWithSize<>(new IsEqual<>(1))
         );
-        new WalletsIn(
-            this.folder.newFolder().toPath()
-        ).create();
+    }
+
+    @Test
+    public void createsWalletInFolder() throws IOException {
+        final Path path = this.folder.newFolder().toPath();
+        final long id = 1L;
+        new WalletsIn(path).create(id);
+        MatcherAssert.assertThat(
+            "Can't create wallet in folder",
+            Files.exists(
+                path.resolve(
+                    new JoinedText(".", Long.toHexString(id), "z").asString()
+                )
+            ),
+            new IsEqual<>(true)
+        );
     }
 }


### PR DESCRIPTION
This is for #12:
 - this covers `Wallet` creation but not the content of the file
 - wrote many tests (one is ignored and has a corresponding `@todo`)
 - introduced 3 `@todo`s to continue the work