### PR TITLE
For #54: Implement the computation of the transaction string.

### DIFF
--- a/src/main/java/io/zold/api/CpTransaction.java
+++ b/src/main/java/io/zold/api/CpTransaction.java
@@ -27,9 +27,10 @@ package io.zold.api;
  * Computed Transaction.
  *
  * @since 1.0
- * @todo #29:30min Implement the computation of the transaction string
- *  based on the white paper. The unit test should also be updated to
- *  ensure it works as expected.
+ * @todo #54:30min Implement the computation of the transaction string
+ *  based on the white paper. The unit tests should also be updated to
+ *  ensure it works as expected and test for
+ *  returnSignatureForNegativeTransaction must be implemented.
  */
 public final class CpTransaction extends TransactionEnvelope {
 

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -73,6 +73,12 @@ public interface Wallet {
     Iterable<Transaction> ledger();
 
     /**
+     * This wallet's RSA key.
+     * @return This wallet's RSA key.
+     */
+    String key();
+
+    /**
      * A Fake {@link Wallet}.
      *
      * @since 1.0
@@ -111,6 +117,11 @@ public interface Wallet {
         @Override
         public Iterable<Transaction> ledger() {
             return new IterableOf<>();
+        }
+
+        @Override
+        public String key() {
+            return Long.toString(this.id);
         }
     }
 
@@ -183,6 +194,16 @@ public interface Wallet {
                     // @checkstyle MagicNumberCheck (1 line)
                     5
                 )
+            );
+        }
+
+        // @todo #54:30min Implement key method. This should return the
+        //  public RSA key of the wallet owner in Base64. Also add a unit test
+        //  to replace WalletTest.keyIsNotYetImplemented().
+        @Override
+        public String key() {
+            throw new UnsupportedOperationException(
+                "key() not yet supported"
             );
         }
     }

--- a/src/test/java/io/zold/api/CpTransactionTest.java
+++ b/src/test/java/io/zold/api/CpTransactionTest.java
@@ -44,10 +44,9 @@ public final class CpTransactionTest {
     @Ignore
     public void returnAmount() throws IOException {
         final long amount = 256;
-        final long wallet = 1024;
         MatcherAssert.assertThat(
             "Cannot return amount",
-            new CpTransaction(amount, wallet).amount(),
+            new CpTransaction(amount, 1024).amount(),
             new IsEqual<>(256)
         );
     }
@@ -55,11 +54,10 @@ public final class CpTransactionTest {
     @Test
     @Ignore
     public void returnSignatureForPositiveTransaction() throws IOException {
-        final long amount = 256;
         final long id = 1024;
         MatcherAssert.assertThat(
             "Cannot return signature",
-            new CpTransaction(amount, id).signature(),
+            new CpTransaction(256, id).signature(),
             new IsEqual<>("1024")
         );
     }
@@ -74,25 +72,23 @@ public final class CpTransactionTest {
     @Test
     @Ignore
     public void returnPrefix() throws IOException {
-        final long amount = 256;
         final long id = 1024;
         final Wallet wallet = new Wallet.Fake(id);
         MatcherAssert.assertThat(
             "Cannot return prefix",
             wallet.key(),
-            new StringContains(new CpTransaction(amount, id).prefix())
+            new StringContains(new CpTransaction(256, id).prefix())
         );
     }
 
     @Test
     @Ignore
     public void returnBeneficiary() throws IOException {
-        final long amount = 256;
         final long id = 1024;
         final Wallet wallet = new Wallet.Fake(id);
         MatcherAssert.assertThat(
             "Cannot return beneficiary",
-            new CpTransaction(amount, id).bnf(),
+            new CpTransaction(256, id).bnf(),
             new IsEqual<>(wallet.key())
         );
     }

--- a/src/test/java/io/zold/api/CpTransactionTest.java
+++ b/src/test/java/io/zold/api/CpTransactionTest.java
@@ -24,6 +24,10 @@
 package io.zold.api;
 
 import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -35,8 +39,61 @@ import org.junit.Test;
  * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class CpTransactionTest {
-    @Test(expected = IOException.class)
-    public void cpTransactionIsNotYetImplemented() throws IOException {
-        new CpTransaction(1, 1234).amount();
+
+    @Test
+    @Ignore
+    public void returnAmount() throws IOException {
+        final long amount = 256;
+        final long wallet = 1024;
+        MatcherAssert.assertThat(
+            "Cannot return amount",
+            new CpTransaction(amount, wallet).amount(),
+            new IsEqual<>(256)
+        );
+    }
+
+    @Test
+    @Ignore
+    public void returnSignatureForPositiveTransaction() throws IOException {
+        final long amount = 256;
+        final long id = 1024;
+        MatcherAssert.assertThat(
+            "Cannot return signature",
+            new CpTransaction(amount, id).signature(),
+            new IsEqual<>("1024")
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void returnSignatureForNegativeTransaction() throws IOException {
+        throw new UnsupportedOperationException(
+            "returnSignatureForNegativeTransaction() not yet implemented"
+        );
+    }
+
+    @Test
+    @Ignore
+    public void returnPrefix() throws IOException {
+        final long amount = 256;
+        final long id = 1024;
+        final Wallet wallet = new Wallet.Fake(id);
+        MatcherAssert.assertThat(
+            "Cannot return prefix",
+            wallet.key(),
+            new StringContains(new CpTransaction(amount, id).prefix())
+        );
+    }
+
+    @Test
+    @Ignore
+    public void returnBeneficiary() throws IOException {
+        final long amount = 256;
+        final long id = 1024;
+        final Wallet wallet = new Wallet.Fake(id);
+        MatcherAssert.assertThat(
+            "Cannot return beneficiary",
+            new CpTransaction(amount, id).bnf(),
+            new IsEqual<>(wallet.key())
+        );
     }
 }

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -110,6 +110,11 @@ public final class WalletTest {
         );
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void keyIsNotYetImplemented() throws IOException {
+        new Wallet.File(this.folder.newFile().toPath()).key();
+    }
+
     private Path wallet(final long id) {
         return this.wallet(Long.toHexString(id));
     }


### PR DESCRIPTION
For #54: Implement the computation of the transaction string
- Added tests for `CpTransaction`
- Added method `key()` in `Wallet` for retrieving RSA key (needed for `prefix` calculation)
- Added implementation of `key()` in `Wallet.Fake`
- Left todos for implement `CpTransaction` and remaining tests
- Left todo for `Wallet.File.key()` implementation
