### PR TITLE
#42 Removed Mockito from NetworkTest

### DIFF
--- a/src/main/java/io/zold/api/Remote.java
+++ b/src/main/java/io/zold/api/Remote.java
@@ -71,20 +71,12 @@ public interface Remote {
 
         /**
          * Ctor.
-         * @param val The remote's score value
+         * @param val The remote's score
          */
         Fake(final int val) {
-            this(val, new HashMap<>());
-        }
-
-        /**
-         * Ctor.
-         * @param val The remote's score
-         * @param wallets Wallets pushed
-         */
-        Fake(final int val, final Map<Long, Wallet> wallets) {
             this(
-                new RtScore(new Repeated<>(val, new RandomText())), wallets
+                new RtScore(new Repeated<>(val, new RandomText())),
+                new HashMap<>()
             );
         }
 
@@ -122,6 +114,14 @@ public interface Remote {
         @Override
         public Wallet pull(final long id) {
             return this.wallets.get(id);
+        }
+
+        /**
+         * Retrieve wallets stored in memory. Used for testing.
+         * @return Pushed wallets
+         */
+        public Map<Long, Wallet> wallets() {
+            return this.wallets;
         }
     }
 }

--- a/src/main/java/io/zold/api/Remote.java
+++ b/src/main/java/io/zold/api/Remote.java
@@ -24,6 +24,9 @@
 
 package io.zold.api;
 
+import java.util.Map;
+import org.cactoos.scalar.UncheckedScalar;
+
 /**
  * Remote node.
  *
@@ -48,4 +51,54 @@ public interface Remote {
      * @return The wallet
      */
     Wallet pull(long id);
+
+    /**
+     * A fake {@link Remote}.
+     */
+    final class Fake implements Remote {
+        /**
+         * Score.
+         */
+        private final Score score;
+        /**
+         * Pushed wallets.
+         */
+        private final Map<Long, Wallet> wallets;
+
+        /**
+         * Ctor.
+         * @param score Score
+         * @param wallets Wallets
+         */
+        Fake(final Score score, final Map<Long, Wallet> wallets) {
+            this.score = score;
+            this.wallets = wallets;
+        }
+
+        @Override
+        public Score score() {
+            return this.score;
+        }
+
+        @Override
+        public void push(final Wallet wallet) {
+            this.wallets.compute(
+                new UncheckedScalar<>(() -> wallet.id()).value(),
+                (id, stored) -> {
+                    final Wallet result;
+                    if (stored == null) {
+                        result = wallet;
+                    } else {
+                        result = stored.merge(wallet);
+                    }
+                    return result;
+                }
+            );
+        }
+
+        @Override
+        public Wallet pull(final long id) {
+            return this.wallets.get(id);
+        }
+    }
 }

--- a/src/main/java/io/zold/api/Remote.java
+++ b/src/main/java/io/zold/api/Remote.java
@@ -80,6 +80,7 @@ public interface Remote {
         /**
          * Ctor.
          * @param val The remote's score
+         * @param wallets Wallets pushed
          */
         Fake(final int val, final Map<Long, Wallet> wallets) {
             this(
@@ -89,8 +90,8 @@ public interface Remote {
 
         /**
          * Ctor.
-         * @param score Score
-         * @param wallets Wallets
+         * @param score The remote's score
+         * @param wallets Wallets pushed
          */
         Fake(final Score score, final Map<Long, Wallet> wallets) {
             this.score = score;

--- a/src/test/java/io/zold/api/NetworkTest.java
+++ b/src/test/java/io/zold/api/NetworkTest.java
@@ -24,8 +24,6 @@
 package io.zold.api;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -48,20 +46,18 @@ public final class NetworkTest {
 
     @Test
     public void pushWalletToAllRemotes()  {
-        final Map<Long, Wallet> highwallets = new HashMap<>();
-        final Remote high = new Remote.Fake(20, highwallets);
-        final Map<Long, Wallet> lowwallets = new HashMap<>();
-        final Remote low = new Remote.Fake(20, lowwallets);
+        final Remote.Fake high = new Remote.Fake(20);
+        final Remote.Fake low = new Remote.Fake(20);
         final long id = 1001L;
         final Wallet wallet = new Wallet.Fake(id);
         new RtNetwork(
             new IterableOf<>(high, low)
         ).push(wallet);
         MatcherAssert.assertThat(
-            highwallets, Matchers.hasKey(id)
+            high.wallets(), Matchers.hasKey(id)
         );
         MatcherAssert.assertThat(
-            lowwallets, Matchers.hasKey(id)
+            low.wallets(), Matchers.hasKey(id)
         );
     }
 

--- a/src/test/java/io/zold/api/NetworkTest.java
+++ b/src/test/java/io/zold/api/NetworkTest.java
@@ -24,14 +24,16 @@
 package io.zold.api;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Repeated;
 import org.cactoos.text.RandomText;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * Test case for {@link Network}.
@@ -43,77 +45,72 @@ import org.mockito.Mockito;
  *  wallets; Network.push must push a wallet to a remote based in remote.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCoupling (2 lines)
  */
 public final class NetworkTest {
 
     @Test
     @Ignore
-    public void pushWalletToRightRemote()  {
-        final Remote highremote = Mockito.mock(Remote.class);
-        final Score highscore = Mockito.mock(Score.class);
-        Mockito.when(highscore.suffixes()).thenReturn(
-            new Repeated<>(20, new RandomText())
+    public void pushWalletToRightRemote() {
+        final Map<Long, Wallet> highwallets = new HashMap<>();
+        final Remote high = new Remote.Fake(
+            new RtScore(new Repeated<>(20, new RandomText())), highwallets
         );
-        Mockito.when(highremote.score()).thenReturn(highscore);
-        final Remote lowremote = Mockito.mock(Remote.class);
-        final Score lowscore = Mockito.mock(Score.class);
-        Mockito.when(lowscore.suffixes()).thenReturn(
-            new Repeated<>(18, new RandomText())
+        final Map<Long, Wallet> lowwallets = new HashMap<>();
+        final Remote low = new Remote.Fake(
+            new RtScore(new Repeated<>(18, new RandomText())), lowwallets
         );
-        Mockito.when(lowremote.score()).thenReturn(lowscore);
-        final Wallet wallet = Mockito.mock(Wallet.class);
+        final long id = 1000L;
+        final Wallet wallet = new Wallet.Fake(id);
         new RtNetwork(
-            new IterableOf<Remote>(
-                highremote, lowremote
-            )
+            new IterableOf<>(high, low)
         ).push(wallet);
-        Mockito.verify(
-            highremote,
-            Mockito.times(1)
-        ).push(Mockito.any(Wallet.class));
-        Mockito.verify(
-            lowremote,
-            Mockito.never()
-        ).push(Mockito.any(Wallet.class));
+        MatcherAssert.assertThat(
+            highwallets, Matchers.hasKey(id)
+        );
+        MatcherAssert.assertThat(
+            lowwallets, Matchers.not(Matchers.hasKey(id))
+        );
     }
 
     @Test
     public void pushWalletToAllRemotes()  {
-        final Remote highremote = Mockito.mock(Remote.class);
-        final Remote lowremote = Mockito.mock(Remote.class);
-        final Wallet wallet = Mockito.mock(Wallet.class);
+        final Map<Long, Wallet> highwallets = new HashMap<>();
+        final Remote high = new Remote.Fake(
+            new RtScore(new Repeated<>(20, new RandomText())), highwallets
+        );
+        final Map<Long, Wallet> lowwallets = new HashMap<>();
+        final Remote low = new Remote.Fake(
+            new RtScore(new Repeated<>(20, new RandomText())), lowwallets
+        );
+        final long id = 1001L;
+        final Wallet wallet = new Wallet.Fake(id);
         new RtNetwork(
-            new IterableOf<Remote>(
-                highremote, lowremote
-            )
+            new IterableOf<>(high, low)
         ).push(wallet);
-        Mockito.verify(
-            highremote,
-            Mockito.times(1)
-        ).push(Mockito.any(Wallet.class));
-        Mockito.verify(
-            lowremote,
-            Mockito.times(1)
-        ).push(Mockito.any(Wallet.class));
+        MatcherAssert.assertThat(
+            highwallets, Matchers.hasKey(id)
+        );
+        MatcherAssert.assertThat(
+            lowwallets, Matchers.hasKey(id)
+        );
     }
 
     @Test
     @Ignore
     public void filtersUnqualifiedRemotesFromPush() {
-        final Remote remote = Mockito.mock(Remote.class);
-        final Score score = Mockito.mock(Score.class);
-        Mockito.when(score.suffixes()).thenReturn(
-            new Repeated<>(15, new RandomText())
+        final long id = 1002L;
+        final Wallet wallet = new Wallet.Fake(id);
+        final Map<Long, Wallet> wallets = new HashMap<>();
+        final Remote remote = new Remote.Fake(
+            new RtScore(new Repeated<>(15, new RandomText())), wallets
         );
-        Mockito.when(remote.score()).thenReturn(score);
-        final Wallet wallet = Mockito.mock(Wallet.class);
         new RtNetwork(
-            new IterableOf<Remote>(remote)
+            new IterableOf<>(remote)
         ).push(wallet);
-        Mockito.verify(
-            remote,
-            Mockito.never()
-        ).push(Mockito.any(Wallet.class));
+        MatcherAssert.assertThat(
+            wallets, Matchers.not(Matchers.hasKey(id))
+        );
     }
 
     @Test

--- a/src/test/java/io/zold/api/TaxesTest.java
+++ b/src/test/java/io/zold/api/TaxesTest.java
@@ -25,7 +25,6 @@ package io.zold.api;
 
 import org.cactoos.iterable.IterableOf;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * Test case for {@link Taxes}.
@@ -37,7 +36,7 @@ public final class TaxesTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void payNotYetSupported() throws Exception {
-        new Taxes(new IterableOf<>()).exec(Mockito.mock(Wallet.class));
+        new Taxes(new IterableOf<>()).exec(new Wallet.Fake(1L));
     }
 
 }


### PR DESCRIPTION
#42: Removed Mockito from `NetworkTest`. Added implementations of `push()` and `pull()` in `Remote.Fake` that can be used for testing purposes.