### PR TITLE
#65: Creating wallets.

### DIFF
--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -131,9 +131,9 @@ public interface Wallet {
         }
 
         /**
-         * Complete Ctor.
+         * Constructor.
          * @param id The wallet id.
-         * @param pubkey The wallet public key.
+         * @param pubkey The public RSA key of the wallet owner.
          * @param network The network the walet belongs to.
          * @checkstyle UnusedFormalParameter (2 lines)
          */

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -114,7 +114,7 @@ public interface Wallet {
         private final Iterable<Transaction> transactions;
 
         /**
-         * Ctor.
+         * Constructor.
          * @param id The wallet id.
          */
         public Fake(final long id) {

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -49,7 +49,8 @@ import org.cactoos.text.UncheckedText;
  *  Beware that tests should be refactored to take care of file cleanup
  *  after each case that merges wallets.
  */
-@SuppressWarnings({"PMD.ShortMethodName", "PMD.TooManyMethods"})
+@SuppressWarnings({"PMD.ShortMethodName", "PMD.TooManyMethods",
+    "PMD.UnusedFormalParameter"})
 public interface Wallet {
     /**
      * This wallet's ID: an unsigned 64-bit integer.
@@ -92,6 +93,13 @@ public interface Wallet {
     /**
      * A Fake {@link Wallet}.
      * @since 1.0
+     * @todo #65:30min Complete Wallet implementations with id, public RSA
+     *  key and network id. Wallets.create(Long, String, String) must
+     *  create a Wallet with these strings set and a constructor must be
+     *  added to all Walletl realizations (Wallet(final long id, final String
+     *  pubkey, final String network, final Transaction... transactions). After
+     *  completing these implementations fix tests that uses Wallets.create()
+     *  and all Wallet realizations.
      */
     final class Fake implements Wallet {
 
@@ -120,6 +128,17 @@ public interface Wallet {
          */
         public Fake(final long id, final Transaction... transactions) {
             this(id, new IterableOf<>(transactions));
+        }
+
+        /**
+         * Complete Ctor.
+         * @param id The wallet id.
+         * @param pubkey The wallet public key.
+         * @param network The network the walet belongs to.
+         * @checkstyle UnusedFormalParameter (2 lines)
+         */
+        public Fake(final long id, final String pubkey, final String network) {
+            this(id);
         }
 
         /**

--- a/src/main/java/io/zold/api/Wallets.java
+++ b/src/main/java/io/zold/api/Wallets.java
@@ -38,4 +38,16 @@ public interface Wallets extends Iterable<Wallet> {
      * @throws IOException If an error occurs.
      */
     Wallet create() throws IOException;
+
+    /**
+     * Create a wallet.
+     *
+     * @param id The wallet id.
+     * @param pubkey The wallet public key.
+     * @param network The network the wallet belongs.
+     * @return The new wallet.
+     * @throws IOException If an error occurs.
+     */
+    Wallet create(final long id, final String pubkey, final String
+        network) throws IOException;
 }

--- a/src/main/java/io/zold/api/WalletsIn.java
+++ b/src/main/java/io/zold/api/WalletsIn.java
@@ -113,9 +113,6 @@ public final class WalletsIn implements Wallets {
         this.random = random;
     }
 
-    // @todo #12:30min Create the new wallet in the path with all wallets.
-    //  It should contain the correct content according to the
-    //  white paper. Also add a the test to validate everything is ok.
     @Override
     public Wallet create() throws IOException {
         final Path wpth = this.path.value().resolve(
@@ -137,6 +134,18 @@ public final class WalletsIn implements Wallets {
         }
         Files.createFile(wpth);
         return new Wallet.File(wpth);
+    }
+
+    @Override
+    // @todo #65:30min Create the new wallet in the path with all wallets.
+    //  It should contain the correct content according to the
+    //  white paper (network, protocol version, id and public RSA key). After
+    //  this remove exception expect for tests on WalletsInTest.
+    public Wallet create(final long id, final String pubkey, final String
+        network) throws IOException {
+        throw new UnsupportedOperationException(
+            "WalletsIn.create(String, String, String) not supported"
+        );
     }
 
     @Override

--- a/src/test/java/io/zold/api/WalletsInTest.java
+++ b/src/test/java/io/zold/api/WalletsInTest.java
@@ -81,6 +81,27 @@ public final class WalletsInTest {
         );
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void createsRightWallet() throws IOException {
+        final Path path = this.folder.newFolder().toPath();
+        final String network = "zold";
+        final String pubkey = "AAAAB3NzaC1yc2EAAAADAQABAAABAQC";
+        final long id = 1;
+        final Wallet actual = new WalletsIn(path).create(
+            id, pubkey, network
+        );
+        final Wallet expected = new Wallet.Fake(
+            id,
+            pubkey,
+            network
+        );
+        MatcherAssert.assertThat(
+            "Created wallet with different values than expected",
+            actual,
+            new IsEqual<>(expected)
+        );
+    }
+
     @Test
     public void doesNotOverwriteExistingWallet() throws Exception {
         final Path path = this.folder.newFolder().toPath();


### PR DESCRIPTION
For #65: Creating wallets.
- Added `createsRightWallet` test which asserts that the right wallet was created
- Added fake constructor with wallet parameters to `Wallet.Fake` so that `createsRightWallet` test compile
- Added method `WalletsIn.create` with parameters which will create `Wallet`
- Added puzzles for filling the added methods and fixing tests.