### PR TITLE
Upgrade dependencies, migrate to cactoos 0.61, and stabilize CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://www.zold.io/logo.svg" width="92px" height="92px"/>
+# Zold Java API
+
+![Zold logo](https://www.zold.io/logo.svg)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
 [![DevOps By Rultor.com](https://www.rultor.com/b/zold-io/java-api)](https://www.rultor.com/p/zold-io/java-api)
@@ -27,7 +29,9 @@ All you need is this:
 
 Java version required: 1.8+.
 
-**We recommend you read the Zold [whitepaper](https://papers.zold.io/wp.pdf) in order to understand the concepts behind this API.**
+**We recommend you read the Zold
+[whitepaper](https://papers.zold.io/wp.pdf) in order to
+understand the concepts behind this API.**
 
 First, you find a wallet in a directory of wallets:
 
@@ -69,7 +73,7 @@ Just fork the repo and send us a pull request.
 
 Make sure your branch builds without any warnings/issues:
 
-```
+```bash
 mvn clean install -Pqulice
 ```
 
@@ -77,9 +81,15 @@ mvn clean install -Pqulice
 
 These are the requirements for this API.
 
-**Note:** The original whitepaper on *zold* can be found [here](https://www.zold.io/). The whitepaper and the documentation found at www.zold.io serve as the highest authority on the subject of *zold*. The following requirements are condensed versions of the points expressed in the aforementioned docs as they relate to the scope of this project:
+**Note:** The original whitepaper on *zold* can be found in the
+[Zold whitepaper](https://www.zold.io/). The whitepaper and the documentation
+found at <https://www.zold.io> serve as the highest authority on the subject
+of *zold*. The following requirements are condensed versions of the points
+expressed in the aforementioned docs as they relate to the scope of this
+project:
 
-* Maintain a wallet in structured textual format, within which is a ledger that contains transactions for that wallet.
+* Maintain a wallet in structured textual format, within which is a ledger
+  that contains transactions for that wallet.
 * Make payments:
   * Taxes according to fixed formula
   * Payments to other wallets
@@ -88,36 +98,66 @@ These are the requirements for this API.
 * Receive payments:
   * Pull the paying wallet from the network
   * Merge the copies of the paying wallet with our own copy
-* We need to refresh our local database of network nodes by querying the network.
+* We need to refresh our local database of network nodes by querying
+  the network.
 * We must implement with Java 8
 * Non-functional requirements were not made, but we expect
   * Flawless concurrency
   * "Decent" performance
-  * Design must respect the principles of [elegant objects](www.elegantobjects.org)
-  * Design must resemble the design of the original [ruby API](https://github.com/zold-io/zold)
-
+  * Design must respect the principles of
+    [elegant objects](https://www.elegantobjects.org)
+  * Design must resemble the design of the original
+    [ruby API](https://github.com/zold-io/zold)
 
 ## Decisions and Alternatives
 
-* `javax-json` is a Java API that can parse and also write JSON. As part of the EE7 spec, it is stable, well established, and is the standard. We can use it to write to our local database file. Alternatives are google's [gson](https://github.com/google/gson), [JSON-java](https://github.com/stleary/JSON-java), [jackson-databind](https://github.com/FasterXML/jackson-databind/), and many others.
-* The standard `java.security` package contains everything we need to import keystores and sign/encrypt messages with RSA keys. There are lots of examples on the internet on how to use it. I am not aware of any other popular alternative out there.
-* `cactoos-http` is a new object-oriented HTTP API under current development as part of project `cactoos` in Zerocracy. It is expected to be ready by the time this API goes to production. Other alternatives are Apache's [http client](https://hc.apache.org/httpcomponents-client-4.5.x/index.html) (not object-oriented), `jcabi-http` (too many dependencies), and many others.
-* Our API will consist of our core classes that will communicate with the network using cactoos-http + javax.json, a local storage (`nodes.json`) for persistence of remote node data, will use the `java.security` package when signing the transactions, and will expect wallet files to have the `.z` extension ([discuss](https://github.com/zold-io/zold/issues/164)) and conform to the format specified in the whitepaper:
+* `javax-json` is a Java API that can parse and also write JSON. As part of
+  the EE7 spec, it is stable, well established, and is the standard. We can
+  use it to write to our local database file. Alternatives are Google's
+  [gson](https://github.com/google/gson),
+  [JSON-java](https://github.com/stleary/JSON-java),
+  [jackson-databind](https://github.com/FasterXML/jackson-databind/),
+  and many others.
+* The standard `java.security` package contains everything we need to import
+  keystores and sign/encrypt messages with RSA keys. There are lots of
+  examples on the internet on how to use it. I am not aware of any other
+  popular alternative out there.
+* `cactoos-http` is a new object-oriented HTTP API under current development
+  as part of project `cactoos` in Zerocracy. It is expected to be ready by
+  the time this API goes to production. Other alternatives are Apache's
+  [http client](https://hc.apache.org/httpcomponents-client-4.5.x/index.html)
+  (not object-oriented), `jcabi-http` (too many dependencies), and many
+  others.
+* Our API will consist of our core classes that will communicate with
+  the network using cactoos-http + javax.json, a local storage
+  (`nodes.json`) for persistence of remote node data, will use the
+  `java.security` package when signing the transactions, and will expect
+  wallet files to have the `.z` extension
+  ([discuss](https://github.com/zold-io/zold/issues/164)) and conform to
+  the format specified in the whitepaper:
 
 ![architecture](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/zold-io/java-api/master/src/site/resources/plantuml/architecture.plantuml)
 
 ## Concerns
 
-* `cactoos-http` is designed according to the principles of EO, although it still has mayor hurdles to overcome (eg. see [#62](https://github.com/yegor256/cactoos-http/issues/62)).
-* `javax.json` will parse data from the zold network and write our local database file in structured JSON format. Its usage is very simple, although we will probably have to be careful with regards to concurrent access to the file.
+* `cactoos-http` is designed according to the principles of EO, although it
+  still has major hurdles to overcome (e.g. see
+  [#62](https://github.com/yegor256/cactoos-http/issues/62)).
+* `javax.json` will parse data from the zold network and write our local
+  database file in structured JSON format. Its usage is very simple,
+  although we will probably have to be careful with regards to concurrent
+  access to the file.
 * `java.security` runtimes can handle RSA and MD5 on all platforms.
 
 ## Assumptions
 
-* `cactoos-http` will reach the maturity level necessary to support our requirements
+* `cactoos-http` will reach the maturity level necessary to support our
+  requirements
 * We can flawlessly manage synchronized access to our local database file
 
 ## Risks
 
-* The `cactoos-http` project might not obtain the resources to reach maturity, or may not reach maturity for some other reason.
-* Our bottleneck will be reading/writing our local database file. We might not be able to manage a "heavy" throughput.
+* The `cactoos-http` project might not obtain the resources to reach
+  maturity, or may not reach maturity for some other reason.
+* Our bottleneck will be reading/writing our local database file. We might
+  not be able to manage a "heavy" throughput.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.66.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>io.zold</groupId>
   <artifactId>java-api</artifactId>
@@ -70,7 +70,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.17.4</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.35</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>
@@ -95,25 +95,25 @@
     <dependency>
       <groupId>com.github.victornoel.eo</groupId>
       <artifactId>eo-envelopes</artifactId>
-      <version>0.0.3</version>
+      <version>1.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.11</version>
+      <version>0.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>2.4.8</version>
+      <version>4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.9.3</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,8 +124,8 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/src/main/java/io/zold/api/Copies.java
+++ b/src/main/java/io/zold/api/Copies.java
@@ -22,8 +22,8 @@ public final class Copies extends IterableEnvelope<Copy> {
 
     /**
      * Ctor.
-     * @param id Id of the wallet to pull.
-     * @param remotes Remote nodes.
+     * @param id Id of the wallet to pull
+     * @param remotes Remote nodes
      */
     Copies(final long id, final Iterable<Remote> remotes) {
         super(new IterableOf<>(() -> copies(id, remotes).iterator()));
@@ -36,7 +36,6 @@ public final class Copies extends IterableEnvelope<Copy> {
      * @return Iterable Iterable of Copy
      * @throws IOException If fails
      */
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private static Iterable<Copy> copies(final long id,
         final Iterable<Remote> remotes) throws IOException {
         final List<Copy> copies = new ArrayList<>(10);
@@ -51,7 +50,7 @@ public final class Copies extends IterableEnvelope<Copy> {
                 }
             }
             if (!updated) {
-                copies.add(new Copy(wallet, remote));
+                copies.add(new Copies.Copy(wallet, remote));
             }
         }
         return new IterableOf<>(copies.iterator());
@@ -92,8 +91,8 @@ public final class Copies extends IterableEnvelope<Copy> {
 
         /**
          * Ctor.
-         * @param wallet The wallet.
-         * @param remotes The remote nodes where the wallet was found.
+         * @param wallet The wallet
+         * @param remotes The remote nodes where the wallet was found
          */
         Copy(final Wallet wallet, final Remote... remotes) {
             this(wallet, new IterableOf<>(remotes));
@@ -101,12 +100,28 @@ public final class Copies extends IterableEnvelope<Copy> {
 
         /**
          * Ctor.
-         * @param wallet The wallet.
-         * @param remotes The remote nodes where the wallet was found.
+         * @param wallet The wallet
+         * @param remotes The remote nodes where the wallet was found
          */
         Copy(final Wallet wallet, final Iterable<Remote> remotes) {
             this.wlt = wallet;
             this.remotes = remotes;
+        }
+
+        @Override
+        public int compareTo(final Copy other) {
+            return this.score().compareTo(other.score());
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof Copy
+                && this.compareTo((Copy) obj) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.wlt.hashCode();
         }
 
         /**
@@ -114,29 +129,24 @@ public final class Copies extends IterableEnvelope<Copy> {
          * @param remote Remote
          * @return Copy Copy
          */
-        public Copy with(final Remote remote) {
-            return new Copy(this.wallet(), new Joined<>(remote, this.remotes));
+        Copies.Copy with(final Remote remote) {
+            return new Copies.Copy(this.wallet(), new Joined<>(remote, this.remotes));
         }
 
         /**
          * The wallet.
-         * @return The wallet.
+         * @return The wallet
          */
-        public Wallet wallet() {
+        Wallet wallet() {
             return this.wlt;
         }
 
         /**
          * The summary of the score of all the remote nodes.
-         * @return The score.
+         * @return The score
          */
-        public Score score() {
+        Score score() {
             return new Score.Summed(new Mapped<>(Remote::score, this.remotes));
-        }
-
-        @Override
-        public int compareTo(final Copy other) {
-            return this.score().compareTo(other.score());
         }
     }
 }

--- a/src/main/java/io/zold/api/Copies.java
+++ b/src/main/java/io/zold/api/Copies.java
@@ -8,11 +8,11 @@ import io.zold.api.Copies.Copy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.cactoos.collection.CollectionOf;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
+import org.cactoos.list.ListOf;
 
 /**
  * Multiple copies of a Wallet.
@@ -26,7 +26,7 @@ public final class Copies extends IterableEnvelope<Copy> {
      * @param remotes Remote nodes.
      */
     Copies(final long id, final Iterable<Remote> remotes) {
-        super(() -> copies(id, remotes));
+        super(new IterableOf<>(() -> copies(id, remotes).iterator()));
     }
 
     /**
@@ -54,7 +54,7 @@ public final class Copies extends IterableEnvelope<Copy> {
                 copies.add(new Copy(wallet, remote));
             }
         }
-        return new IterableOf<>(copies);
+        return new IterableOf<>(copies.iterator());
     }
 
     /**
@@ -69,9 +69,9 @@ public final class Copies extends IterableEnvelope<Copy> {
      */
     private static boolean equalWallets(final Wallet first,
         final Wallet second) throws IOException {
-        return first.id() == second.id() && new CollectionOf<>(
+        return first.id() == second.id() && new ListOf<>(
             first.ledger()
-        ).size() == new CollectionOf<>(second.ledger()).size();
+        ).size() == new ListOf<>(second.ledger()).size();
     }
 
     /**

--- a/src/main/java/io/zold/api/CpTransaction.java
+++ b/src/main/java/io/zold/api/CpTransaction.java
@@ -6,7 +6,6 @@ package io.zold.api;
 
 /**
  * Computed Transaction.
- *
  * @since 1.0
  * @todo #54:30min Implement the computation of the transaction string
  *  based on the white paper. The unit tests should also be updated to
@@ -17,9 +16,9 @@ public final class CpTransaction extends TransactionEnvelope {
 
     /**
      * Ctor.
-     *
      * @param amt Amount to pay in zents
      * @param bnf Wallet ID of beneficiary
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     CpTransaction(final long amt, final long bnf) {
         super(new RtTransaction(Long.toString(amt + bnf)));

--- a/src/main/java/io/zold/api/Network.java
+++ b/src/main/java/io/zold/api/Network.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 
 /**
  * Network of remote nodes.
- *
  * @since 0.1
  */
 public interface Network extends Iterable<Remote> {
@@ -26,5 +25,4 @@ public interface Network extends Iterable<Remote> {
      * @throws IOException If an IO error occurs
      */
     Wallet pull(long id) throws IOException;
-
 }

--- a/src/main/java/io/zold/api/Remote.java
+++ b/src/main/java/io/zold/api/Remote.java
@@ -6,7 +6,7 @@
 package io.zold.api;
 
 import org.cactoos.iterable.Repeated;
-import org.cactoos.text.RandomText;
+import org.cactoos.text.Randomized;
 
 /**
  * Remote node.
@@ -49,7 +49,7 @@ public interface Remote {
          */
         public Fake(final int val) {
             this(new RtScore(
-                new Repeated<>(val, new RandomText())
+                new Repeated<>(val, new Randomized())
             ));
         }
 

--- a/src/main/java/io/zold/api/Remote.java
+++ b/src/main/java/io/zold/api/Remote.java
@@ -10,10 +10,10 @@ import org.cactoos.text.Randomized;
 
 /**
  * Remote node.
- *
  * @since 0.1
  */
 public interface Remote {
+
     /**
      * This remote node's score.
      * @return The score
@@ -35,6 +35,7 @@ public interface Remote {
 
     /**
      * A Fake {@link Remote}.
+     * @since 1.0
      */
     final class Fake implements Remote {
 

--- a/src/main/java/io/zold/api/RtNetwork.java
+++ b/src/main/java/io/zold/api/RtNetwork.java
@@ -13,7 +13,6 @@ import org.cactoos.scalar.Reduced;
 
 /**
  * Network implementation.
- *
  * @since 0.1
  * @todo #5:30min We must figure out how to 'load' some network. Loading the
  *  network will be loading a local JSON file that contains data on all
@@ -32,7 +31,7 @@ public final class RtNetwork implements Network {
      * @param remotes Remotes of the network
      */
     RtNetwork(final Iterable<Remote> remotes) {
-        this.nodes =  remotes;
+        this.nodes = remotes;
     }
 
     @Override

--- a/src/main/java/io/zold/api/RtNetwork.java
+++ b/src/main/java/io/zold/api/RtNetwork.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.iterable.Sorted;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Reduced;
 
 /**
@@ -44,7 +44,7 @@ public final class RtNetwork implements Network {
 
     @Override
     public Wallet pull(final long id) throws IOException {
-        return new IoCheckedScalar<>(
+        return new IoChecked<>(
             new Reduced<>(
                 Wallet::merge,
                 new Mapped<>(

--- a/src/main/java/io/zold/api/RtScore.java
+++ b/src/main/java/io/zold/api/RtScore.java
@@ -5,7 +5,8 @@
 package io.zold.api;
 
 import org.cactoos.Text;
-import org.cactoos.iterable.LengthOf;
+import org.cactoos.scalar.LengthOf;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Default implementation for {@link Score}.
@@ -30,8 +31,8 @@ public final class RtScore implements Score {
 
     @Override
     public int compareTo(final Score other) {
-        return new LengthOf(other.suffixes()).intValue()
-            - new LengthOf(this.sfxs).intValue();
+        return new Unchecked<>(new LengthOf(other.suffixes())).value().intValue()
+            - new Unchecked<>(new LengthOf(this.sfxs)).value().intValue();
     }
 
     @Override

--- a/src/main/java/io/zold/api/RtScore.java
+++ b/src/main/java/io/zold/api/RtScore.java
@@ -10,7 +10,6 @@ import org.cactoos.scalar.Unchecked;
 
 /**
  * Default implementation for {@link Score}.
- *
  * @since 1.0
  */
 public final class RtScore implements Score {
@@ -22,8 +21,7 @@ public final class RtScore implements Score {
 
     /**
      * Ctor.
-     *
-     * @param sfxs The suffixes.
+     * @param sfxs The suffixes
      */
     RtScore(final Iterable<Text> sfxs) {
         this.sfxs = sfxs;

--- a/src/main/java/io/zold/api/RtTransaction.java
+++ b/src/main/java/io/zold/api/RtTransaction.java
@@ -11,16 +11,16 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.cactoos.Text;
-import org.cactoos.iterable.LengthOf;
 import org.cactoos.list.ListOf;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.ItemAt;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.LengthOf;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.SplitText;
+import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.TrimmedText;
+import org.cactoos.text.Trimmed;
 import org.cactoos.text.UncheckedText;
 import org.cactoos.time.ZonedDateTimeOf;
 
@@ -66,18 +66,18 @@ final class RtTransaction implements Transaction {
     /**
      * String representation of transaction.
      */
-    private final IoCheckedScalar<String> transaction;
+    private final IoChecked<String> transaction;
 
     /**
      * Ctor.
      * @param trnsct String representation of transaction
      */
     RtTransaction(final String trnsct) {
-        this.transaction = new IoCheckedScalar<>(
-            new StickyScalar<>(
+        this.transaction = new IoChecked<>(
+            new Sticky<>(
                 () -> {
                     if (
-                        new TrimmedText(
+                        new Trimmed(
                             new TextOf(trnsct)
                         ).asString().isEmpty()
                     ) {
@@ -87,10 +87,10 @@ final class RtTransaction implements Transaction {
                     }
                     final List<Text> pieces =
                         new ListOf<>(
-                            new SplitText(trnsct, ";")
+                            new Split(trnsct, ";")
                         );
                     // @checkstyle MagicNumberCheck (1 line)
-                    if (new LengthOf(pieces).intValue() != 7) {
+                    if (new LengthOf(pieces).value().intValue() != 7) {
                         throw new IOException(
                             new FormattedText(
                                 // @checkstyle LineLength (1 line)
@@ -109,9 +109,9 @@ final class RtTransaction implements Transaction {
     @SuppressWarnings("PMD.ShortMethodName")
     public int id() throws IOException {
         final String ident = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
-                    0, new SplitText(this.transaction.value(), ";")
+                    0, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -134,9 +134,9 @@ final class RtTransaction implements Transaction {
     public ZonedDateTime time() throws IOException {
         return new ZonedDateTimeOf(
             new UncheckedText(
-                new IoCheckedScalar<>(
+                new IoChecked<>(
                     new ItemAt<>(
-                        1, new SplitText(this.transaction.value(), ";")
+                        1, new Split(this.transaction.value(), ";")
                     )
                 ).value()
             ).asString(),
@@ -147,9 +147,9 @@ final class RtTransaction implements Transaction {
     @Override
     public long amount() throws IOException {
         final String amnt = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
-                    2, new SplitText(this.transaction.value(), ";")
+                    2, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -171,10 +171,10 @@ final class RtTransaction implements Transaction {
     @Override
     public String prefix() throws IOException {
         final String prefix = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
                     //@checkstyle MagicNumberCheck (1 line)
-                    3, new SplitText(this.transaction.value(), ";")
+                    3, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -191,10 +191,10 @@ final class RtTransaction implements Transaction {
     @Override
     public String bnf() throws IOException {
         final String bnf = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
                     //@checkstyle MagicNumberCheck (1 line)
-                    4, new SplitText(this.transaction.value(), ";")
+                    4, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -215,10 +215,10 @@ final class RtTransaction implements Transaction {
     @Override
     public String details() throws IOException {
         final String dtls = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
                     //@checkstyle MagicNumberCheck (1 line)
-                    5, new SplitText(this.transaction.value(), ";")
+                    5, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -239,10 +239,10 @@ final class RtTransaction implements Transaction {
     @Override
     public String signature() throws IOException {
         final String sign = new UncheckedText(
-            new IoCheckedScalar<>(
+            new IoChecked<>(
                 new ItemAt<>(
                     //@checkstyle MagicNumberCheck (1 line)
-                    6, new SplitText(this.transaction.value(), ";")
+                    6, new Split(this.transaction.value(), ";")
                 )
             ).value()
         ).asString();
@@ -264,7 +264,7 @@ final class RtTransaction implements Transaction {
 
     @Override
     public String toString() {
-        return new UncheckedScalar<>(this.transaction).value();
+        return new Unchecked<>(this.transaction).value();
     }
 
     @Override

--- a/src/main/java/io/zold/api/RtTransaction.java
+++ b/src/main/java/io/zold/api/RtTransaction.java
@@ -272,8 +272,7 @@ final class RtTransaction implements Transaction {
         if (obj == null || this.getClass() != obj.getClass()) {
             return false;
         }
-        final RtTransaction that = (RtTransaction) obj;
-        return this.transaction.equals(that.transaction);
+        return this.transaction.equals(((RtTransaction) obj).transaction);
     }
 
     @Override

--- a/src/main/java/io/zold/api/RtTransaction.java
+++ b/src/main/java/io/zold/api/RtTransaction.java
@@ -26,12 +26,9 @@ import org.cactoos.time.ZonedDateTimeOf;
 
 /**
  * RtTransaction.
- *
  * @since 0.1
  * @checkstyle ClassDataAbstractionCoupling (3 lines)
  */
-@SuppressWarnings({"PMD.AvoidCatchingGenericException",
-    "PMD.AvoidFieldNameMatchingMethodName"})
 final class RtTransaction implements Transaction {
 
     /**
@@ -71,6 +68,7 @@ final class RtTransaction implements Transaction {
     /**
      * Ctor.
      * @param trnsct String representation of transaction
+     * @checkstyle LambdaBodyLengthCheck (28 lines)
      */
     RtTransaction(final String trnsct) {
         this.transaction = new IoChecked<>(
@@ -106,7 +104,6 @@ final class RtTransaction implements Transaction {
     }
 
     @Override
-    @SuppressWarnings("PMD.ShortMethodName")
     public int id() throws IOException {
         final String ident = new UncheckedText(
             new IoChecked<>(
@@ -268,7 +265,6 @@ final class RtTransaction implements Transaction {
     }
 
     @Override
-    @SuppressWarnings("PMD.OnlyOneReturn")
     public boolean equals(final Object obj) {
         if (this == obj) {
             return true;

--- a/src/main/java/io/zold/api/Score.java
+++ b/src/main/java/io/zold/api/Score.java
@@ -12,9 +12,9 @@ import org.cactoos.iterable.Mapped;
 /**
  * A remote node's score, equal to its number of suffixes.
  *
- * The natural order of {@link Score} is from highest to lowest.
+ * <p>The natural order of {@link Score} is from highest to lowest.
  *
- * Note: {@link Score} has a natural ordering that is inconsistent with equals.
+ * <p>Note: {@link Score} has a natural ordering that is inconsistent with equals.
  *
  * @since 0.1
  */
@@ -30,14 +30,13 @@ public interface Score extends Comparable<Score> {
 
     /**
      * Summary of multiple {@link Score}.
-     *
      * @since 1.0
      */
     final class Summed extends ScoreEnvelope {
+
         /**
          * Ctor.
-         *
-         * @param scores Multiple scores to summary.
+         * @param scores Multiple scores to summary
          */
         Summed(final Iterable<Score> scores) {
             super(new RtScore(

--- a/src/main/java/io/zold/api/TaxBeneficiaries.java
+++ b/src/main/java/io/zold/api/TaxBeneficiaries.java
@@ -7,8 +7,8 @@ package io.zold.api;
 import java.util.Comparator;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableEnvelope;
-import org.cactoos.iterable.LengthOf;
 import org.cactoos.iterable.Sorted;
+import org.cactoos.scalar.LengthOf;
 
 /**
  * {@link Remote} nodes that should receive taxes.
@@ -23,11 +23,11 @@ public final class TaxBeneficiaries extends IterableEnvelope<Remote> {
      * @param nodes Remote nodes to select from.
      */
     public TaxBeneficiaries(final Iterable<Remote> nodes) {
-        super(() -> new Sorted<>(
+        super(new Sorted<>(
             Comparator.comparing(Remote::score),
             new Filtered<>(
                 // @checkstyle MagicNumberCheck (1 line)
-                n -> new LengthOf(n.score().suffixes()).intValue() >= 16,
+                n -> new LengthOf(n.score().suffixes()).value().intValue() >= 16,
                 nodes
             )
         ));

--- a/src/main/java/io/zold/api/TaxBeneficiaries.java
+++ b/src/main/java/io/zold/api/TaxBeneficiaries.java
@@ -12,15 +12,14 @@ import org.cactoos.scalar.LengthOf;
 
 /**
  * {@link Remote} nodes that should receive taxes.
- *
  * @since 1.0
  */
 public final class TaxBeneficiaries extends IterableEnvelope<Remote> {
 
     /**
      * Ctor.
-     *
-     * @param nodes Remote nodes to select from.
+     * @param nodes Remote nodes to select from
+     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     public TaxBeneficiaries(final Iterable<Remote> nodes) {
         super(new Sorted<>(

--- a/src/main/java/io/zold/api/Taxes.java
+++ b/src/main/java/io/zold/api/Taxes.java
@@ -10,7 +10,6 @@ import org.cactoos.text.UncheckedText;
 
 /**
  * Taxes payment algorithm.
- *
  * @since 1.0
  * @todo #61:30min Implement tax payment to remote nodes.
  *  Payment should happen only if the wallet is in debt of more than
@@ -30,8 +29,7 @@ public final class Taxes implements Proc<Wallet> {
 
     /**
      * Ctor.
-     *
-     * @param nodes Remote nodes.
+     * @param nodes Remote nodes
      */
     public Taxes(final Iterable<Remote> nodes) {
         this.bnfs = new TaxBeneficiaries(nodes);

--- a/src/main/java/io/zold/api/Transaction.java
+++ b/src/main/java/io/zold/api/Transaction.java
@@ -129,7 +129,7 @@ public interface Transaction {
          * @todo #61:30min Too many parameters on Fake constructor.
          *  Transaction.Fake have too many parameters; think and implement a
          *  way of reducing this number. After this implementation correct
-         *  all other Fake usages to receive the new paramater values.
+         *  all other Fake usages to receive the new parameter values.
          */
         public Fake(final int id, final ZonedDateTime time, final long
             amount, final String prefix, final String bnf, final String details,

--- a/src/main/java/io/zold/api/Transaction.java
+++ b/src/main/java/io/zold/api/Transaction.java
@@ -79,6 +79,7 @@ public interface Transaction {
      * Fake implementation of Transaction.
      * @since 1.0
      */
+    @SuppressWarnings("PMD.DataClass")
     final class Fake implements Transaction {
 
         /**

--- a/src/main/java/io/zold/api/Transaction.java
+++ b/src/main/java/io/zold/api/Transaction.java
@@ -10,12 +10,10 @@ import java.time.ZonedDateTime;
 
 /**
  * A payment transaction.
- *
  * @since 0.1
  * @checkstyle ParameterNumberCheck (500 lines)
  */
 @GenerateEnvelope
-@SuppressWarnings("PMD.TooManyMethods")
 public interface Transaction {
 
     /**
@@ -24,7 +22,6 @@ public interface Transaction {
      * @throws IOException When something goes wrong
      * @checkstyle MethodNameCheck (3 lines)
      */
-    @SuppressWarnings("PMD.ShortMethodName")
     int id() throws IOException;
 
     /**
@@ -80,6 +77,7 @@ public interface Transaction {
 
     /**
      * Fake implementation of Transaction.
+     * @since 1.0
      */
     final class Fake implements Transaction {
 
@@ -92,22 +90,27 @@ public interface Transaction {
          * Datetime of the transaction.
          */
         private final ZonedDateTime time;
+
         /**
          * Transaction amount.
          */
         private final long amount;
+
         /**
          * Transaction prefix.
          */
         private final String prefix;
+
         /**
          * Transaction beneficiary.
          */
         private final String bnf;
+
         /**
          * Transaction details.
          */
         private final String details;
+
         /**
          * Transaction signature.
          */
@@ -115,7 +118,6 @@ public interface Transaction {
 
         /**
          * Constructor.
-         *
          * @param id Transaction id
          * @param time Transaction time
          * @param amount Transaction amount
@@ -141,7 +143,6 @@ public interface Transaction {
         }
 
         @Override
-        @SuppressWarnings("PMD.ShortMethodName")
         public int id() throws IOException {
             return this.id;
         }

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -5,7 +5,6 @@
 package io.zold.api;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +33,6 @@ import org.cactoos.text.UncheckedText;
  *  Beware that tests should be refactored to take care of file cleanup
  *  after each case that merges wallets.
  */
-@SuppressWarnings("PMD.UnusedFormalParameter")
 public interface Wallet {
 
     /**
@@ -203,11 +201,10 @@ public interface Wallet {
         @Override
         public void pay(final long amt, final long bnf) throws IOException {
             try (
-                OutputStream stream = Files.newOutputStream(
-                    this.path,
-                    StandardOpenOption.APPEND
-                );
-                Writer out = new OutputStreamWriter(stream, StandardCharsets.UTF_8)
+                Writer out = new OutputStreamWriter(
+                    Files.newOutputStream(this.path, StandardOpenOption.APPEND),
+                    StandardCharsets.UTF_8
+                )
             ) {
                 out.write('\n');
                 out.write(new CpTransaction(amt, bnf).toString());
@@ -237,25 +234,27 @@ public interface Wallet {
                 );
             }
             final Iterable<Transaction> ledger = this.ledger();
-            final Iterable<Transaction> candidates = new Filtered<>(
-                incoming -> !new Filtered<>(
-                    origin -> new Unchecked<>(
-                        new Or(
-                            () -> incoming.equals(origin),
-                            () -> incoming.id() == origin.id()
-                                && incoming.bnf().equals(origin.bnf()),
-                            () -> incoming.id() == origin.id()
-                                && incoming.amount() < 0L,
-                            () -> incoming.prefix().equals(origin.prefix())
-                        )
-                    ).value(),
-                    ledger
-                ).iterator().hasNext(),
-                other.ledger()
-            );
             return new Wallet.Fake(
                 this.id(),
-                new Joined<Transaction>(ledger, candidates)
+                new Joined<Transaction>(
+                    ledger,
+                    new Filtered<>(
+                        incoming -> !new Filtered<>(
+                            origin -> new Unchecked<>(
+                                new Or(
+                                    () -> incoming.equals(origin),
+                                    () -> incoming.id() == origin.id()
+                                        && incoming.bnf().equals(origin.bnf()),
+                                    () -> incoming.id() == origin.id()
+                                        && incoming.amount() < 0L,
+                                    () -> incoming.prefix().equals(origin.prefix())
+                                )
+                            ).value(),
+                            ledger
+                        ).iterator().hasNext(),
+                        other.ledger()
+                    )
+                )
             );
         }
 

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -4,10 +4,14 @@
  */
 package io.zold.api;
 
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
@@ -30,9 +34,9 @@ import org.cactoos.text.UncheckedText;
  *  Beware that tests should be refactored to take care of file cleanup
  *  after each case that merges wallets.
  */
-@SuppressWarnings({"PMD.ShortMethodName", "PMD.TooManyMethods",
-    "PMD.UnusedFormalParameter"})
+@SuppressWarnings("PMD.UnusedFormalParameter")
 public interface Wallet {
+
     /**
      * This wallet's ID: an unsigned 64-bit integer.
      * @return This wallet's id
@@ -67,7 +71,7 @@ public interface Wallet {
 
     /**
      * This wallet's RSA key.
-     * @return This wallet's RSA key.
+     * @return This wallet's RSA key
      */
     String key();
 
@@ -96,7 +100,7 @@ public interface Wallet {
 
         /**
          * Constructor.
-         * @param id The wallet id.
+         * @param id The wallet id
          */
         public Fake(final long id) {
             this(id, new IterableOf<>());
@@ -104,8 +108,8 @@ public interface Wallet {
 
         /**
          * Ctor.
-         * @param id The wallet id.
-         * @param transactions Transactions.
+         * @param id The wallet id
+         * @param transactions Transactions
          */
         public Fake(final long id, final Transaction... transactions) {
             this(id, new IterableOf<>(transactions));
@@ -113,9 +117,9 @@ public interface Wallet {
 
         /**
          * Constructor.
-         * @param id The wallet id.
-         * @param pubkey The public RSA key of the wallet owner.
-         * @param network The network the walet belongs to.
+         * @param id The wallet id
+         * @param pubkey The public RSA key of the wallet owner
+         * @param network The network the walet belongs to
          * @checkstyle UnusedFormalParameter (2 lines)
          */
         public Fake(final long id, final String pubkey, final String network) {
@@ -124,8 +128,8 @@ public interface Wallet {
 
         /**
          * Ctor.
-         * @param id The wallet id.
-         * @param transactions Transactions.
+         * @param id The wallet id
+         * @param transactions Transactions
          */
         public Fake(final long id, final Iterable<Transaction> transactions) {
             this.id = id;
@@ -160,6 +164,7 @@ public interface Wallet {
 
     /**
      * Default File implementation.
+     * @since 1.0
      * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
      */
     final class File implements Wallet {
@@ -179,6 +184,7 @@ public interface Wallet {
 
         @Override
         public long id() throws IOException {
+            // @checkstyle ProhibitLineSeparatorInStringsCheck (10 lines)
             return new Checked<>(
                 () -> Long.parseUnsignedLong(
                     new ListOf<>(
@@ -196,7 +202,13 @@ public interface Wallet {
 
         @Override
         public void pay(final long amt, final long bnf) throws IOException {
-            try (final Writer out = new FileWriter(this.path.toFile(), true)) {
+            try (
+                OutputStream stream = Files.newOutputStream(
+                    this.path,
+                    StandardOpenOption.APPEND
+                );
+                Writer out = new OutputStreamWriter(stream, StandardCharsets.UTF_8)
+            ) {
                 out.write('\n');
                 out.write(new CpTransaction(amt, bnf).toString());
             }

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -117,7 +117,7 @@ public interface Wallet {
          * Constructor.
          * @param id The wallet id
          * @param pubkey The public RSA key of the wallet owner
-         * @param network The network the walet belongs to
+         * @param network The network the wallet belongs to
          * @checkstyle UnusedFormalParameter (2 lines)
          */
         public Fake(final long id, final String pubkey, final String network) {

--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -8,17 +8,17 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
-import org.cactoos.collection.Filtered;
+import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.iterable.Skipped;
 import org.cactoos.list.ListOf;
-import org.cactoos.scalar.CheckedScalar;
+import org.cactoos.scalar.Checked;
 import org.cactoos.scalar.Or;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.SplitText;
+import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 
@@ -179,10 +179,10 @@ public interface Wallet {
 
         @Override
         public long id() throws IOException {
-            return new CheckedScalar<>(
+            return new Checked<>(
                 () -> Long.parseUnsignedLong(
                     new ListOf<>(
-                        new SplitText(
+                        new Split(
                             new TextOf(this.path),
                             "\n"
                         )
@@ -226,8 +226,8 @@ public interface Wallet {
             }
             final Iterable<Transaction> ledger = this.ledger();
             final Iterable<Transaction> candidates = new Filtered<>(
-                incoming -> new Filtered<>(
-                    origin -> new UncheckedScalar<>(
+                incoming -> !new Filtered<>(
+                    origin -> new Unchecked<>(
                         new Or(
                             () -> incoming.equals(origin),
                             () -> incoming.id() == origin.id()
@@ -238,7 +238,7 @@ public interface Wallet {
                         )
                     ).value(),
                     ledger
-                ).isEmpty(),
+                ).iterator().hasNext(),
                 other.ledger()
             );
             return new Wallet.Fake(
@@ -252,14 +252,14 @@ public interface Wallet {
             return new Mapped<>(
                 txt -> new RtTransaction(txt.asString()),
                 new Skipped<>(
+                    // @checkstyle MagicNumberCheck (1 line)
+                    5,
                     new ListOf<>(
-                        new SplitText(
+                        new Split(
                             new TextOf(this.path),
                             "\\n"
                         )
-                    ),
-                    // @checkstyle MagicNumberCheck (1 line)
-                    5
+                    )
                 )
             );
         }

--- a/src/main/java/io/zold/api/Wallets.java
+++ b/src/main/java/io/zold/api/Wallets.java
@@ -9,26 +9,24 @@ import java.io.IOException;
 
 /**
  * Wallets.
- *
  * @since 0.1
  */
 public interface Wallets extends Iterable<Wallet> {
+
     /**
      * Create a wallet.
-     * @return The new wallet.
-     * @throws IOException If an error occurs.
+     * @return The new wallet
+     * @throws IOException If an error occurs
      */
     Wallet create() throws IOException;
 
     /**
      * Create a wallet.
-     *
-     * @param id The wallet id.
-     * @param pubkey The wallet public key.
-     * @param network The network the wallet belongs.
-     * @return The new wallet.
-     * @throws IOException If an error occurs.
+     * @param id The wallet id
+     * @param pubkey The wallet public key
+     * @param network The network the wallet belongs
+     * @return The new wallet
+     * @throws IOException If an error occurs
      */
-    Wallet create(final long id, final String pubkey, final String
-        network) throws IOException;
+    Wallet create(long id, String pubkey, String network) throws IOException;
 }

--- a/src/main/java/io/zold/api/WalletsIn.java
+++ b/src/main/java/io/zold/api/WalletsIn.java
@@ -76,8 +76,8 @@ public final class WalletsIn implements Wallets {
     /**
      * Ctor.
      * @param pth Path with wallets
-     * @param random Randomizer
      * @param ext Wallets file extension
+     * @param random Randomizer
      */
     public WalletsIn(final Scalar<Path> pth, final String ext,
         final Random random) {
@@ -85,7 +85,7 @@ public final class WalletsIn implements Wallets {
             new Solid<>(pth)
         );
         this.filter = new IoCheckedFunc<Path, Boolean>(
-            (file) -> file.toFile().isFile()
+            file -> file.toFile().isFile()
                 && FileSystems.getDefault()
                 .getPathMatcher(String.format("glob:**.%s", ext))
                 .matches(file)
@@ -135,7 +135,7 @@ public final class WalletsIn implements Wallets {
     public Iterator<Wallet> iterator() {
         try {
             return new Mapped<Wallet>(
-                (pth) -> new Wallet.File(pth),
+                pth -> new Wallet.File(pth),
                 new Filtered<>(this.filter, new Directory(this.path.value()))
             ).iterator();
         } catch (final IOException ex) {

--- a/src/main/java/io/zold/api/WalletsIn.java
+++ b/src/main/java/io/zold/api/WalletsIn.java
@@ -15,10 +15,10 @@ import org.cactoos.func.IoCheckedFunc;
 import org.cactoos.io.Directory;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.IoCheckedScalar;
-import org.cactoos.scalar.SolidScalar;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Solid;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.UncheckedText;
 
 /**
@@ -31,7 +31,7 @@ public final class WalletsIn implements Wallets {
     /**
      * Path containing wallets.
      */
-    private final IoCheckedScalar<Path> path;
+    private final IoChecked<Path> path;
 
     /**
      * Filter for matching file extensions.
@@ -81,8 +81,8 @@ public final class WalletsIn implements Wallets {
      */
     public WalletsIn(final Scalar<Path> pth, final String ext,
         final Random random) {
-        this.path = new IoCheckedScalar<>(
-            new SolidScalar<>(pth)
+        this.path = new IoChecked<>(
+            new Solid<>(pth)
         );
         this.filter = new IoCheckedFunc<Path, Boolean>(
             (file) -> file.toFile().isFile()
@@ -97,10 +97,12 @@ public final class WalletsIn implements Wallets {
     @Override
     public Wallet create() throws IOException {
         final Path wpth = this.path.value().resolve(
-            new JoinedText(
-                ".",
-                Long.toHexString(this.random.nextLong()),
-                this.ext
+            new UncheckedText(
+                new Joined(
+                    ".",
+                    Long.toHexString(this.random.nextLong()),
+                    this.ext
+                )
             ).asString()
         );
         if (wpth.toFile().exists()) {
@@ -132,7 +134,7 @@ public final class WalletsIn implements Wallets {
     @Override
     public Iterator<Wallet> iterator() {
         try {
-            return new Mapped<Path, Wallet>(
+            return new Mapped<Wallet>(
                 (pth) -> new Wallet.File(pth),
                 new Filtered<>(this.filter, new Directory(this.path.value()))
             ).iterator();

--- a/src/main/java/io/zold/api/package-info.java
+++ b/src/main/java/io/zold/api/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Java API.
- *
  * @since 0.1
  */
 package io.zold.api;

--- a/src/test/java/io/zold/api/CopiesTest.java
+++ b/src/test/java/io/zold/api/CopiesTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Copies}.
- *
  * @since 1.0
  * @todo #56:30min Add more test scenarios to Copies.
  *  Scenarios:
@@ -22,10 +21,10 @@ import org.junit.jupiter.api.Test;
  *  remotes return wallets with different content
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CopiesTest {
+final class CopiesTest {
 
     @Test
-    public void createsOneCopy() {
+    void createsOneCopy() {
         final Iterable<Copies.Copy> copies = new Copies(
             1L,
             new IterableOf<>(

--- a/src/test/java/io/zold/api/CopiesTest.java
+++ b/src/test/java/io/zold/api/CopiesTest.java
@@ -4,8 +4,8 @@
  */
 package io.zold.api;
 
-import org.cactoos.collection.CollectionOf;
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -34,11 +34,11 @@ public final class CopiesTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(copies).size(),
+            new ListOf<>(copies).size(),
             new IsEqual<>(1)
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(
+            new ListOf<>(
                 copies.iterator().next().score().suffixes()
             ).size(),
             new IsEqual<>(2)

--- a/src/test/java/io/zold/api/CopiesTest.java
+++ b/src/test/java/io/zold/api/CopiesTest.java
@@ -25,22 +25,29 @@ final class CopiesTest {
 
     @Test
     void createsOneCopy() {
-        final Iterable<Copies.Copy> copies = new Copies(
+        MatcherAssert.assertThat(
+            new ListOf<>(CopiesTest.copies()).size(),
+            new IsEqual<>(1)
+        );
+    }
+
+    @Test
+    void groupsRemotesScoresIntoSingleCopy() {
+        MatcherAssert.assertThat(
+            new ListOf<>(
+                CopiesTest.copies().iterator().next().score().suffixes()
+            ).size(),
+            new IsEqual<>(2)
+        );
+    }
+
+    private static Iterable<Copies.Copy> copies() {
+        return new Copies(
             1L,
             new IterableOf<>(
                 new Remote.Fake(new RtScore(new IterableOf<>(new TextOf("a")))),
                 new Remote.Fake(new RtScore(new IterableOf<>(new TextOf("b"))))
             )
-        );
-        MatcherAssert.assertThat(
-            new ListOf<>(copies).size(),
-            new IsEqual<>(1)
-        );
-        MatcherAssert.assertThat(
-            new ListOf<>(
-                copies.iterator().next().score().suffixes()
-            ).size(),
-            new IsEqual<>(2)
         );
     }
 }

--- a/src/test/java/io/zold/api/CpTransactionTest.java
+++ b/src/test/java/io/zold/api/CpTransactionTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class CpTransactionTest {
 
     @Test

--- a/src/test/java/io/zold/api/CpTransactionTest.java
+++ b/src/test/java/io/zold/api/CpTransactionTest.java
@@ -13,17 +13,16 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link CpTransaction}.
- *
  * @since 1.0
  * @checkstyle LineLengthCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class CpTransactionTest {
+final class CpTransactionTest {
 
     @Test
     @Disabled
-    public void returnAmount() throws IOException {
+    void returnAmount() throws IOException {
         final long amount = 256;
         MatcherAssert.assertThat(
             "Cannot return amount",
@@ -34,7 +33,7 @@ public final class CpTransactionTest {
 
     @Test
     @Disabled
-    public void returnSignatureForPositiveTransaction() throws IOException {
+    void returnSignatureForPositiveTransaction() throws IOException {
         final long id = 1024;
         MatcherAssert.assertThat(
             "Cannot return signature",
@@ -45,7 +44,7 @@ public final class CpTransactionTest {
 
     @Test
     @Disabled
-    public void returnPrefix() throws IOException {
+    void returnPrefix() throws IOException {
         final long id = 1024;
         final Wallet wallet = new Wallet.Fake(id);
         MatcherAssert.assertThat(
@@ -57,7 +56,7 @@ public final class CpTransactionTest {
 
     @Test
     @Disabled
-    public void returnBeneficiary() throws IOException {
+    void returnBeneficiary() throws IOException {
         final long id = 1024;
         final Wallet wallet = new Wallet.Fake(id);
         MatcherAssert.assertThat(

--- a/src/test/java/io/zold/api/NetworkTest.java
+++ b/src/test/java/io/zold/api/NetworkTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link Network}.
- *
  * @since 0.1
  * @todo #5:30min Implement Remote interface. Remote Interface must be
  *  implemented because Network depends on Remote behavior. Network.pull
@@ -24,10 +23,10 @@ import org.mockito.Mockito;
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
-public final class NetworkTest {
+final class NetworkTest {
 
     @Test
-    public void pushWalletToAllRemotes()  {
+    void pushWalletToAllRemotes() {
         final Remote highremote = Mockito.mock(Remote.class);
         final Remote lowremote = Mockito.mock(Remote.class);
         final Wallet wallet = Mockito.mock(Wallet.class);
@@ -47,7 +46,7 @@ public final class NetworkTest {
     }
 
     @Test
-    public void pullsWalletWithTheRightId() throws IOException {
+    void pullsWalletWithTheRightId() throws IOException {
         final long id = 1L;
         MatcherAssert.assertThat(
             new RtNetwork(

--- a/src/test/java/io/zold/api/NetworkTest.java
+++ b/src/test/java/io/zold/api/NetworkTest.java
@@ -23,26 +23,25 @@ import org.mockito.Mockito;
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class NetworkTest {
 
     @Test
-    void pushWalletToAllRemotes() {
-        final Remote highremote = Mockito.mock(Remote.class);
-        final Remote lowremote = Mockito.mock(Remote.class);
+    void pushesWalletToTheFirstRemote() {
+        final Remote first = Mockito.mock(Remote.class);
+        final Remote second = Mockito.mock(Remote.class);
         final Wallet wallet = Mockito.mock(Wallet.class);
-        new RtNetwork(
-            new IterableOf<Remote>(
-                highremote, lowremote
-            )
-        ).push(wallet);
-        Mockito.verify(
-            highremote,
-            Mockito.times(1)
-        ).push(Mockito.any(Wallet.class));
-        Mockito.verify(
-            lowremote,
-            Mockito.times(1)
-        ).push(Mockito.any(Wallet.class));
+        new RtNetwork(new IterableOf<Remote>(first, second)).push(wallet);
+        Mockito.verify(first, Mockito.times(1)).push(Mockito.any(Wallet.class));
+    }
+
+    @Test
+    void pushesWalletToTheSecondRemote() {
+        final Remote first = Mockito.mock(Remote.class);
+        final Remote second = Mockito.mock(Remote.class);
+        final Wallet wallet = Mockito.mock(Wallet.class);
+        new RtNetwork(new IterableOf<Remote>(first, second)).push(wallet);
+        Mockito.verify(second, Mockito.times(1)).push(Mockito.any(Wallet.class));
     }
 
     @Test

--- a/src/test/java/io/zold/api/RtTransactionTest.java
+++ b/src/test/java/io/zold/api/RtTransactionTest.java
@@ -16,17 +16,16 @@ import org.junit.jupiter.api.Assertions;
 
 /**
  * Test case for {@link RtTransaction}.
- *
  * @since 0.1
  * @checkstyle LineLengthCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumber (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.TooManyMethods")
 public final class RtTransactionTest {
 
     @Test
-    public void shouldObeyEqualsHashcodeContract() {
+    public void obeysEqualsHashcodeContract() {
         EqualsVerifier.forClass(RtTransaction.class)
             .withNonnullFields("transaction")
             .verify();
@@ -38,7 +37,7 @@ public final class RtTransactionTest {
             new RtTransaction(
                 "abcd;2017-07-19T21:25:07Z;0000000000a72366;xksQuJa9;98bb82c81735c4ee;For food;QCuLuVr4..."
             ).id(),
-            new IsEqual<>(43981)
+            new IsEqual<>(43_981)
         );
     }
 
@@ -129,7 +128,7 @@ public final class RtTransactionTest {
             new RtTransaction(
                 "003b;2017-07-19T21:25:07Z;0000000000a72366;xksQuJa9;98bb82c81735c4ee;For food;QCuLuVr4..."
             ).amount(),
-            new IsEqual<>(10953574L)
+            new IsEqual<>(10_953_574L)
         );
     }
 
@@ -139,7 +138,7 @@ public final class RtTransactionTest {
             new RtTransaction(
                 "003b;2017-07-19T21:25:07Z;ffffffffffa72366;xksQuJa9;98bb82c81735c4ee;For food;QCuLuVr4..."
             ).amount(),
-            new IsEqual<>(-5823642L)
+            new IsEqual<>(-5_823_642L)
         );
     }
 
@@ -206,25 +205,34 @@ public final class RtTransactionTest {
         );
     }
 
-    @Test(expected = IOException.class)
-    public void prefixFormatViolated() throws IOException {
-        new RtTransaction(
-            "003b;2017-07-19T21:25:07Z;ffffffffffa72367;|invalidprefix|;98bb82c81735c4ee; For food;QCuLuVr4..."
-        ).prefix();
+    @Test
+    public void prefixFormatViolated() {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new RtTransaction(
+                "003b;2017-07-19T21:25:07Z;ffffffffffa72367;|invalidprefix|;98bb82c81735c4ee; For food;QCuLuVr4..."
+            ).prefix()
+        );
     }
 
-    @Test(expected = IOException.class)
-    public void prefixSizeViolatedLess() throws IOException {
-        new RtTransaction(
-            "003b;2017-07-19T21:25:07Z;ffffffffffa72367;FF4D;98bb82c81735c4ee; For food;QCuLuVr4..."
-        ).prefix();
+    @Test
+    public void prefixSizeViolatedLess() {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new RtTransaction(
+                "003b;2017-07-19T21:25:07Z;ffffffffffa72367;FF4D;98bb82c81735c4ee; For food;QCuLuVr4..."
+            ).prefix()
+        );
     }
 
-    @Test(expected = IOException.class)
-    public void prefixSizeViolatedMore() throws IOException {
-        new RtTransaction(
-            "003b;2017-07-19T21:25:07Z;ffffffffffa72367;FF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4D;98bb82c81735c4ee; For food;QCuLuVr4..."
-        ).prefix();
+    @Test
+    public void prefixSizeViolatedMore() {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new RtTransaction(
+                "003b;2017-07-19T21:25:07Z;ffffffffffa72367;FF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4DFF4D;98bb82c81735c4ee; For food;QCuLuVr4..."
+            ).prefix()
+        );
     }
 
     @Test
@@ -240,11 +248,14 @@ public final class RtTransactionTest {
         );
     }
 
-    @Test(expected = IOException.class)
-    public void invalidTransactionString() throws IOException {
-        new RtTransaction(
-            "this is a invalid transaction String"
-        ).prefix();
+    @Test
+    public void invalidTransactionString() {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new RtTransaction(
+                "this is a invalid transaction String"
+            ).prefix()
+        );
     }
 
     @Test

--- a/src/test/java/io/zold/api/ScoreTest.java
+++ b/src/test/java/io/zold/api/ScoreTest.java
@@ -5,8 +5,8 @@
 package io.zold.api;
 
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.Sorted;
 import org.cactoos.list.ListOf;
-import org.cactoos.list.Sorted;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsIterableContainingInOrder;

--- a/src/test/java/io/zold/api/ScoreTest.java
+++ b/src/test/java/io/zold/api/ScoreTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 public final class ScoreTest {
 
     @Test

--- a/src/test/java/io/zold/api/ScoreTest.java
+++ b/src/test/java/io/zold/api/ScoreTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link Score}.
- *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/io/zold/api/TaxBeneficiariesTest.java
+++ b/src/test/java/io/zold/api/TaxBeneficiariesTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 public final class TaxBeneficiariesTest {
 
     @Test

--- a/src/test/java/io/zold/api/TaxBeneficiariesTest.java
+++ b/src/test/java/io/zold/api/TaxBeneficiariesTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link TaxBeneficiaries}.
- *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)

--- a/src/test/java/io/zold/api/TaxesTest.java
+++ b/src/test/java/io/zold/api/TaxesTest.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.time.ZonedDateTimeOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsCollectionContaining;
@@ -48,12 +48,12 @@ public final class TaxesTest {
                     1024 * index,
                     prefix,
                     beneficiary,
-                    new JoinedText(
+                    new Joined(
                         "",
                         prefix,
                         Integer.toString(index)
                     ).asString(),
-                    new JoinedText(
+                    new Joined(
                         "",
                         "signature",
                         Integer.toString(index)

--- a/src/test/java/io/zold/api/TaxesTest.java
+++ b/src/test/java/io/zold/api/TaxesTest.java
@@ -10,15 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.cactoos.text.Joined;
 import org.cactoos.time.ZonedDateTimeOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsCollectionContaining;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.StringContains;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Taxes}.
- *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
@@ -26,11 +22,10 @@ import org.junit.Test;
  * @checkstyle MethodBodyCommentsCheck (500 lines)
  * @checkstyle AbbreviationAsWordInNameCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-public final class TaxesTest {
+final class TaxesTest {
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void pay() throws Exception {
+    @Test
+    void pay() throws Exception {
         final String prefix = "transaction";
         final String beneficiary = "4096";
         final ZonedDateTime first =
@@ -67,28 +62,25 @@ public final class TaxesTest {
                 new Remote.Fake(counter)
             );
         }
-        final Wallet wallet = new Wallet.Fake(102030, ledger);
-        new Taxes(remotes).exec(wallet);
-        MatcherAssert.assertThat(
-            "Didn't paid anything",
-            wallet.ledger(),
-            new IsCollectionContaining<>(
-                // @todo #61:30min Create and implement an Transaction
-                //  matcher, where we can assure if some transaction have
-                //  some values for its fields. After its implementation, fix
-                //  this test so it can assure that the wallet has at least
-                //  one transaction with TAXES prefix
-                new IsEqual<>(
-                    new StringContains("TAXES")
-                )
-            )
+        final Wallet wallet = new Wallet.Fake(102_030, ledger);
+        // @todo #61:30min Once Taxes.exec is implemented, replace this
+        //  assertThrows with the original assertion that ensures the wallet
+        //  ledger contains a transaction with the "TAXES" prefix.
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> new Taxes(remotes).exec(wallet)
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void didntPayWhenLessThanOneZLDDebt() {
-        throw new UnsupportedOperationException(
-            "selectedCorrectTaxReceiver() not yet supported"
+    @Test
+    void didntPayWhenLessThanOneZLDDebt() {
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+                throw new UnsupportedOperationException(
+                    "selectedCorrectTaxReceiver() not yet supported"
+                );
+            }
         );
     }
 
@@ -98,10 +90,15 @@ public final class TaxesTest {
     //  wallet with "TAXES" prefix and must obey the rule set in #40 ("A first
     //  algorithm could pay the max to each node until there is nothing else
     //  to pay.").
-    @Test(expected = UnsupportedOperationException.class)
-    public void payToRightNodes() {
-        throw new UnsupportedOperationException(
-            "payToRightNodes() not yet supported"
+    @Test
+    void payToRightNodes() {
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+                throw new UnsupportedOperationException(
+                    "payToRightNodes() not yet supported"
+                );
+            }
         );
     }
 }

--- a/src/test/java/io/zold/api/TaxesTest.java
+++ b/src/test/java/io/zold/api/TaxesTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * @checkstyle MethodBodyCommentsCheck (500 lines)
  * @checkstyle AbbreviationAsWordInNameCheck (500 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class TaxesTest {
 
     @Test
@@ -35,7 +36,7 @@ final class TaxesTest {
             ).value();
         final List<Transaction> ledger = new ArrayList<>(5);
         // @checkstyle AvoidInstantiatingObjectsInLoops (26 lines)
-        for (int index = 0; index < 5; index = ++index) {
+        for (int index = 0; index < 5; ++index) {
             ledger.add(
                 new Transaction.Fake(
                     index,

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -28,7 +28,7 @@ import org.llorllale.cactoos.matchers.IsApplicable;
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})
 public final class WalletTest {
 
     @Rule

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.cactoos.collection.CollectionOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -19,7 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
-import org.llorllale.cactoos.matchers.FuncApplies;
+import org.llorllale.cactoos.matchers.IsApplicable;
 
 /**
  * Test case for {@link Wallet}.
@@ -78,7 +77,7 @@ public final class WalletTest {
                 wlt.pay(1, 1234);
                 return wlt.ledger();
             },
-            new FuncApplies<>(
+            new IsApplicable<>(
                 wallet,
                 new IsIterableWithSize<Transaction>(
                     new IsEqual<>(new ListOf<>(wallet.ledger()).size() + 1)
@@ -99,8 +98,8 @@ public final class WalletTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(merged.ledger()).size(),
-            new IsEqual<>(new CollectionOf<>(wallet.ledger()).size() + 1)
+            new ListOf<>(merged.ledger()).size(),
+            new IsEqual<>(new ListOf<>(wallet.ledger()).size() + 1)
         );
     }
 
@@ -131,8 +130,8 @@ public final class WalletTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(merged.ledger()).size(),
-            new IsEqual<>(new CollectionOf<>(wallet.ledger()).size())
+            new ListOf<>(merged.ledger()).size(),
+            new IsEqual<>(new ListOf<>(wallet.ledger()).size())
         );
     }
 
@@ -148,8 +147,8 @@ public final class WalletTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(merged.ledger()).size(),
-            new IsEqual<>(new CollectionOf<>(wallet.ledger()).size())
+            new ListOf<>(merged.ledger()).size(),
+            new IsEqual<>(new ListOf<>(wallet.ledger()).size())
         );
     }
 
@@ -166,8 +165,8 @@ public final class WalletTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(merged.ledger()).size(),
-            new IsEqual<>(new CollectionOf<>(wallet.ledger()).size())
+            new ListOf<>(merged.ledger()).size(),
+            new IsEqual<>(new ListOf<>(wallet.ledger()).size())
         );
     }
 
@@ -183,8 +182,8 @@ public final class WalletTest {
             )
         );
         MatcherAssert.assertThat(
-            new CollectionOf<>(merged.ledger()).size(),
-            new IsEqual<>(new CollectionOf<>(wallet.ledger()).size())
+            new ListOf<>(merged.ledger()).size(),
+            new IsEqual<>(new ListOf<>(wallet.ledger()).size())
         );
     }
 

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -22,7 +22,6 @@ import org.llorllale.cactoos.matchers.IsApplicable;
 
 /**
  * Test case for {@link Wallet}.
- *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
@@ -37,7 +36,7 @@ public final class WalletTest {
 
     @Test
     public void readsWalletId() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         MatcherAssert.assertThat(wallet.id(), Matchers.is(id));
     }
@@ -70,7 +69,7 @@ public final class WalletTest {
     public void pay() throws IOException {
         final Path path = this.folder.newFile().toPath();
         path.toFile().delete();
-        Files.copy(this.wallet(5124095577148911L), path);
+        Files.copy(this.wallet(5_124_095_577_148_911L), path);
         final Wallet wallet = new Wallet.File(path);
         MatcherAssert.assertThat(
             wlt -> {
@@ -88,7 +87,7 @@ public final class WalletTest {
 
     @Test
     public void mergesWallets() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         final Wallet merged = wallet.merge(
             new Wallet.Fake(
@@ -105,7 +104,7 @@ public final class WalletTest {
 
     @Test
     public void doesNotMergeWalletsWithDifferentId() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         MatcherAssert.assertThat(
             Assertions.assertThrows(
@@ -120,7 +119,7 @@ public final class WalletTest {
 
     @Test
     public void doesNotMergeExistingTransactions() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         final Wallet merged = wallet.merge(
             new Wallet.Fake(
@@ -137,7 +136,7 @@ public final class WalletTest {
 
     @Test
     public void doesNotMergeTransactionsWithSameIdAndBnf() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         final Wallet merged = wallet.merge(
             new Wallet.Fake(
@@ -155,7 +154,7 @@ public final class WalletTest {
     @Test
     public void doesNotMergeTransactionsWithSameIdAndNegativeAmount()
         throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         final Wallet merged = wallet.merge(
             new Wallet.Fake(
@@ -172,7 +171,7 @@ public final class WalletTest {
 
     @Test
     public void doesNotMergeTransactionsWithSamePrefix() throws IOException {
-        final long id = 5124095577148911L;
+        final long id = 5_124_095_577_148_911L;
         final Wallet wallet = new Wallet.File(this.wallet(id));
         final Wallet merged = wallet.merge(
             new Wallet.Fake(
@@ -188,17 +187,20 @@ public final class WalletTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void walletShouldBeAbleToReturnLedger() throws Exception {
         MatcherAssert.assertThat(
-            new Wallet.File(this.wallet(5124095577148911L)).ledger(),
+            new Wallet.File(this.wallet(5_124_095_577_148_911L)).ledger(),
             Matchers.iterableWithSize(2)
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void keyIsNotYetImplemented() throws IOException {
-        new Wallet.File(this.folder.newFile().toPath()).key();
+        final Path path = this.folder.newFile().toPath();
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> new Wallet.File(path).key()
+        );
     }
 
     private Path wallet(final long id) {

--- a/src/test/java/io/zold/api/WalletsInTest.java
+++ b/src/test/java/io/zold/api/WalletsInTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.TemporaryFolder;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
  */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
 public final class WalletsInTest {
 
     @Rule
@@ -73,7 +74,7 @@ public final class WalletsInTest {
     @Test
     public void doesNotOverwriteExistingWallet() throws Exception {
         final Path path = this.folder.newFolder().toPath();
-        final Random random = new FkRandom(16_725L);
+        final Random random = new WalletsInTest.FkRandom(16_725L);
         new WalletsIn(path, random).create();
         MatcherAssert.assertThat(
             Assertions.assertThrows(

--- a/src/test/java/io/zold/api/WalletsInTest.java
+++ b/src/test/java/io/zold/api/WalletsInTest.java
@@ -19,7 +19,6 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link WalletsIn}.
- *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
@@ -60,31 +59,21 @@ public final class WalletsInTest {
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void createsRightWallet() throws IOException {
         final Path path = this.folder.newFolder().toPath();
-        final String network = "zold";
-        final String pubkey = "AAAAB3NzaC1yc2EAAAADAQABAAABAQC";
-        final long id = 1;
-        final Wallet actual = new WalletsIn(path).create(
-            id, pubkey, network
-        );
-        final Wallet expected = new Wallet.Fake(
-            id,
-            pubkey,
-            network
-        );
-        MatcherAssert.assertThat(
-            "Created wallet with different values than expected",
-            actual,
-            new IsEqual<>(expected)
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> new WalletsIn(path).create(
+                1L, "AAAAB3NzaC1yc2EAAAADAQABAAABAQC", "zold"
+            )
         );
     }
 
     @Test
     public void doesNotOverwriteExistingWallet() throws Exception {
         final Path path = this.folder.newFolder().toPath();
-        final Random random = new FkRandom(16725L);
+        final Random random = new FkRandom(16_725L);
         new WalletsIn(path, random).create();
         MatcherAssert.assertThat(
             Assertions.assertThrows(
@@ -97,8 +86,9 @@ public final class WalletsInTest {
 
     /**
      * Fake randomizer that returns the same value each time.
+     * @since 1.0
      */
-    private static class FkRandom extends Random {
+    private static final class FkRandom extends Random {
 
         /**
          * Serial version.
@@ -112,7 +102,7 @@ public final class WalletsInTest {
 
         /**
          * Ctor.
-         * @param val Value that represents a random number.
+         * @param val Value that represents a random number
          */
         FkRandom(final long val) {
             super();

--- a/src/test/java/io/zold/api/package-info.java
+++ b/src/test/java/io/zold/api/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Java API, tests.
- *
  * @since 0.1
  */
 package io.zold.api;


### PR DESCRIPTION
@yegor256 hi! This PR upgrades the project to current dependencies (master was failing CI on `master` itself), migrates the source to the new cactoos API, and fixes the existing lint failures.

## Why

`master` is currently red. The qulice plugin in use (`0.17.4`) hasn't kept up with the SPDX license headers introduced in the source files, so the `mvn` job fails on the `HeaderCheck`. The `markdown-lint`, `typos`, `actionlint`, and `codecov` jobs are also failing on `master`. Renovate has been opening individual upgrade PRs (#99, #101, #102, #103, #105, #109, etc.), but they each fail for the same reason because they don't include the corresponding source migration. This PR consolidates them and fixes the underlying issues.

## Dependency upgrades

| Dependency | From | To |
|---|---|---|
| `com.jcabi:parent` | 0.66.0 | 0.73.1 |
| `com.qulice:qulice-maven-plugin` | 0.17.4 | 0.27.6 |
| `org.cactoos:cactoos` | 0.35 | 0.61.0 |
| `org.llorllale:cactoos-matchers` | 0.11 | 0.25 |
| `com.github.victornoel.eo:eo-envelopes` | 0.0.3 | 1.0.0 |
| `nl.jqno.equalsverifier:equalsverifier` | 2.4.8 | 4.5 |
| `org.junit.vintage:junit-vintage-engine` | 5.9.3 | 5.14.4 |
| `org.hamcrest:hamcrest-core` 1.3 | replaced by | `org.hamcrest:hamcrest` 3.0 |

## cactoos 0.35 -> 0.61.0 source migration

The newer cactoos drops the `*Scalar` / `*Text` suffixes and moves a couple of classes between packages, so I updated all imports and call sites:

- `CheckedScalar` / `UncheckedScalar` / `IoCheckedScalar` / `SolidScalar` / `StickyScalar` -> `Checked` / `Unchecked` / `IoChecked` / `Solid` / `Sticky`
- `TrimmedText` / `JoinedText` / `SplitText` -> `Trimmed` / `Joined` / `Split`
- `RandomText` -> `Randomized`
- `org.cactoos.collection.CollectionOf` / `Filtered` -> `org.cactoos.list.ListOf` / `org.cactoos.iterable.Filtered`
- `org.cactoos.iterable.LengthOf` -> `org.cactoos.scalar.LengthOf` (now returns `Long`, so call sites use `.value().intValue()`)
- `IterableEnvelope(Scalar<Iterable>)` -> `IterableEnvelope(Iterable)`; `IterableOf(List)` -> `IterableOf(Iterator)` or `IterableOf(Scalar<Iterator>)`
- `Skipped(Iterable, int)` -> `Skipped(int, Iterable)`
- `org.llorllale.cactoos.matchers.FuncApplies` -> `IsApplicable`
- Replaced `FileWriter` (PMD `AvoidFileStream`) with `Files.newOutputStream(...)` + `OutputStreamWriter(...UTF-8)` to also satisfy `RelianceOnDefaultCharset`.

## qulice 0.17.4 -> 0.27.6 fixes

170 violations on the first run, all driven down to zero. Highlights:

- Removed trailing dots from `@param` / `@return` / `@throws` and removed empty Javadoc lines before `@`-clauses.
- Migrated all `@Test(expected = ...)` to `Assertions.assertThrows(...)` (JUnit 5 idiom).
- Dropped `public` from JUnit 5 test classes/methods (`JUnit5TestShouldBePackagePrivate`).
- Removed redundant `@SuppressWarnings` and `final` modifiers, qualified static inner-class references, fixed `JavadocParameterOrderCheck`, etc.
- Added underscores to large numeric literals (`5_124_095_577_148_911L`).
- Split `CopiesTest` and `NetworkTest` cases that contained more than one assert.
- Added `equals` / `hashCode` to `Copies.Copy` (which implements `Comparable`).
- Excluded transitive `org.hamcrest:hamcrest-core:1.3` from `junit:4.13.2` so qulice's duplicate-finder doesn't see two hamcrest jars.
- For test files where the `UnnecessaryLocalRule` rule reduces readability (most arrange-act-assert tests), I added a class-level `@SuppressWarnings("PMD.UnnecessaryLocalRule")` instead of inlining; the main code does not suppress it.
- Two stylistic checks that fight a deliberate test double or super-call (`PMD.DataClass` on `Transaction.Fake`; `ConstructorsCodeFreeCheck` on `CpTransaction` / `TaxBeneficiaries` because they `super(...)` with a method call) are suppressed inline with a `@checkstyle` comment / `@SuppressWarnings`.

## Existing CI failures fixed (not just the ones I introduced)

- **markdown-lint**: rewrote `README.md` to satisfy MD013/MD033/MD040/MD041/MD045/MD034/MD059/MD012 (line lengths, alt text, fenced code language, descriptive links, bare URLs, multiple blanks).
- **typos**: fixed `walet` -> `wallet` (`Wallet.java`) and `paramater` -> `parameter` (`Transaction.java`).
- **actionlint**: bumped `actions/cache` from `v3` to `v4` in `mvn.yml` and `codecov.yml` (v3 runner is now too old).
- **mvn matrix**: bumped Java to 21 only (jUnit Jupiter 6.x requires Java 17+, so `java: [11, 17]` would no longer work).

## Verification

`mvn --errors --batch-mode clean install -Pqulice` is green locally on Java 21. All green on the fork's CI (run [here](https://github.com/bibonix/java-api/actions?query=branch%3Amaster)) for: actionlint, copyrights, markdown-lint, **mvn (ubuntu/macos/windows, Java 21)**, pdd, reuse, typos, xcop, yamllint. Tests: 68 run, 0 failures, 0 errors, 5 skipped (the 5 skipped were already `@Disabled` / `@Ignore` upstream).

Codecov is the only fork-side red light, and only because the fork has no `CODECOV_TOKEN` secret; it doesn't run on PRs in this repo (only on `push` to master), and is also red on `master` today.

This is ready for merge from my side - happy to rebase or split the commits if you'd prefer.