### PR TITLE
fix: #128 swap ours and theirs in Wallet.File.merge error

### DIFF
--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -227,8 +227,8 @@ public interface Wallet {
                     new UncheckedText(
                         new FormattedText(
                             "Wallet ID mismatch, ours is %d, theirs is %d",
-                            other.id(),
-                            this.id()
+                            this.id(),
+                            other.id()
                         )
                     ).asString()
                 );

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -112,7 +112,7 @@ public final class WalletTest {
                 () -> wallet.merge(new Wallet.Fake(123L))
             ).getMessage(),
             Matchers.startsWith(
-                "Wallet ID mismatch, ours is 123, theirs is 5124095577148911"
+                "Wallet ID mismatch, ours is 5124095577148911, theirs is 123"
             )
         );
     }


### PR DESCRIPTION
The IOException thrown by Wallet.File.merge on an id mismatch labelled the other wallet's id as ours and this wallet's id as theirs, so a maintainer reading the message followed the labels to the wrong side of the comparison. The guard `other.id() != this.id()` itself was correct; only the FormattedText arguments were ordered wrong.

This change swaps the two arguments so the label matches the value, and updates the assertion in WalletTest.doesNotMergeWalletsWithDifferentId that pinned the previous buggy message. No other call site is touched.

Verified locally with `mvn --batch-mode -Pqulice clean install` on Java 21: BUILD SUCCESS, qulice clean, 68 tests run with 0 failures, 0 errors, 1 skipped.

Closes #128