### PR TITLE
fix: #74 implement Wallet.File.key

### DIFF
--- a/src/main/java/io/zold/api/Wallet.java
+++ b/src/main/java/io/zold/api/Wallet.java
@@ -70,8 +70,9 @@ public interface Wallet {
     /**
      * This wallet's RSA key.
      * @return This wallet's RSA key
+     * @throws IOException If an IO error occurs
      */
-    String key();
+    String key() throws IOException;
 
     /**
      * A Fake {@link Wallet}.
@@ -275,14 +276,19 @@ public interface Wallet {
             );
         }
 
-        // @todo #54:30min Implement key method. This should return the
-        //  public RSA key of the wallet owner in Base64. Also add a unit test
-        //  to replace WalletTest.keyIsNotYetImplemented().
         @Override
-        public String key() {
-            throw new UnsupportedOperationException(
-                "key() not yet supported"
-            );
+        public String key() throws IOException {
+            // @checkstyle ProhibitLineSeparatorInStringsCheck (10 lines)
+            return new Checked<>(
+                () -> new ListOf<>(
+                    new Split(
+                        new TextOf(this.path),
+                        "\n"
+                    )
+                // @checkstyle MagicNumberCheck (1 line)
+                ).get(3).asString(),
+                e -> new IOException(e)
+            ).value();
         }
     }
 }

--- a/src/test/java/io/zold/api/WalletTest.java
+++ b/src/test/java/io/zold/api/WalletTest.java
@@ -195,11 +195,13 @@ public final class WalletTest {
     }
 
     @Test
-    public void keyIsNotYetImplemented() throws IOException {
-        final Path path = this.folder.newFile().toPath();
-        Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> new Wallet.File(path).key()
+    public void readsPublicKey() throws IOException {
+        MatcherAssert.assertThat(
+            new Wallet.File(this.wallet(5_124_095_577_148_911L)).key(),
+            Matchers.is(
+                // @checkstyle LineLengthCheck (1 line)
+                "MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgGZCr/9hBChqsChd4sRAIpKNRinjhSW+J+S7PU5malVMiRHVoKjeooLDpWpij0A6vkzOvjrMldAZT0Fzgp0cJ15TOVwiQanQ5WuQDgRkLoxrdh/qyBApoDvk4OUEozOQPNwfpZOFfaUALPsPnv9995TlY9WcdSKW5dj041p1tJmlAgMBAAE="
+            )
         );
     }
 


### PR DESCRIPTION
`Wallet.File.key()` threw `UnsupportedOperationException("key() not yet supported")` since the class was introduced, and the matching puzzle in the source has been open as #74 from 2018. Any caller that asked a file-backed wallet for its RSA key tripped the exception at runtime; `Copies.equalWallets` in #79 reaches for `Wallet.key()` and would have hit the same wall once both sides were `Wallet.File`.

The implementation reuses the cactoos `Split`/`ListOf` chain that `Wallet.File.id` already uses and returns the fourth line of the wallet file, which is where the base64 RSA key is recorded according to the existing fixtures under `src/test/resources/wallets` and `src/test/resources/walletsIn`. The `Wallet` interface gains `throws IOException` on `key()` so the file-backed reader can surface I/O failures the same way `id` and `merge` already do; `Wallet.Fake.key()` keeps its signature because it does no I/O. The placeholder `WalletTest.keyIsNotYetImplemented` is replaced by `readsPublicKey`, which asserts the value embedded in the `12345678abcdef` fixture comes back unchanged.

Ran `mvn -B test` (68 tests, 0 failures, 5 skipped — same skipped set as `master`) and `mvn -B -Pqulice -DskipTests verify` to confirm Qulice still passes.

Closes #74
