### PR TITLE
fix: #131 use SecureRandom for default wallet id generator

### DIFF
--- a/src/main/java/io/zold/api/WalletsIn.java
+++ b/src/main/java/io/zold/api/WalletsIn.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Random;
 import org.cactoos.Scalar;
@@ -56,7 +57,7 @@ public final class WalletsIn implements Wallets {
         this(
             () -> pth,
             "z",
-            new Random()
+            new SecureRandom()
         );
     }
 


### PR DESCRIPTION
The default constructor `WalletsIn(Path)` was seeding wallet-id generation with `new java.util.Random()`, the 48-bit LCG that #131 flagged as recoverable from a small handful of observed outputs. That let any observer of past ids enumerate upcoming ones and race the existence check on the next `create()` call. The two-arg constructor that takes a caller-supplied `Random` was kept untouched so deterministic test seeds stay unchanged.

Switched the default to `new java.security.SecureRandom()`. `SecureRandom` extends `Random`, so the rest of the constructor chain and the `random.nextLong()` call inside `create()` need no further adjustment. The change is two lines in `WalletsIn.java`: one new import and one swapped allocator.

Local checks: `mvn -B test` (68 tests, 0 failures, 5 skipped — same skipped set as `master`) and `mvn -B -Pqulice -DskipTests verify` both pass on this branch.

Closes #131
